### PR TITLE
Refine audio streaming pipeline and add tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,218 @@
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+class _FakeAudioMedia:
+    def __init__(self):
+        self._transmit = []
+
+    def startTransmit(self, other):  # pragma: no cover - behaviour tested via agent
+        self._transmit.append(other)
+
+    def stopTransmit(self, other):  # pragma: no cover - compatibility shim
+        if other in self._transmit:
+            self._transmit.remove(other)
+
+
+class _FakeCall:
+    def __init__(self, acc=None, call_id=0):
+        self.acc = acc
+        self.call_id = call_id
+        self._audio_media = _FakeAudioMedia()
+        self._info = types.SimpleNamespace(
+            stateText="", state=0, role=0, lastStatusCode=0
+        )
+
+    def getAudioMedia(self, index):
+        return self._audio_media
+
+    def getInfo(self):
+        return self._info
+
+    def makeCall(self, target_uri, call_prm):  # pragma: no cover - stub
+        self._last_invite = (target_uri, call_prm)
+
+
+class _FakeAccount:
+    def __init__(self, ep=None):
+        self.ep = ep
+
+    def create(self, cfg):  # pragma: no cover - stub
+        self.cfg = cfg
+
+    def setRegistration(self, value):  # pragma: no cover - stub
+        self.registered = value
+
+
+class _FakeEndpoint:
+    def __init__(self):
+        self.transport = None
+
+    def utilTimerSchedule(self, timer, time_val):  # pragma: no cover - stub
+        timer._callback()
+
+    def utilTimerCancel(self, timer):  # pragma: no cover - stub
+        pass
+
+    def libCreate(self):  # pragma: no cover - stub
+        pass
+
+    def libInit(self, cfg):  # pragma: no cover - stub
+        self.cfg = cfg
+
+    def libStart(self):  # pragma: no cover - stub
+        pass
+
+    def libDestroy(self):  # pragma: no cover - stub
+        pass
+
+    def libDelete(self):  # pragma: no cover - stub
+        pass
+
+    def transportCreate(self, transport_type, cfg):  # pragma: no cover - stub
+        self.transport = cfg
+        return types.SimpleNamespace()
+
+    def codecEnum2(self):  # pragma: no cover - stub
+        return []
+
+    def codecSetPriority(self, codec, priority):  # pragma: no cover - stub
+        pass
+
+
+class _FakeEpConfig:
+    def __init__(self):
+        self.medConfig = types.SimpleNamespace(jbMin=0, jbMax=0, jbMaxPre=0)
+        self.uaConfig = types.SimpleNamespace(stunServer=[])
+
+
+class _FakeCallOpParam:
+    def __init__(self):
+        self.opt = types.SimpleNamespace(audioCount=0, videoCount=0)
+        self.statusCode = 0
+
+
+class _FakeTimeVal:
+    def __init__(self):
+        self.sec = 0
+        self.msec = 0
+
+
+class _FakeAccountConfig:
+    def __init__(self):
+        self.idUri = ""
+        self.regConfig = types.SimpleNamespace(registrarUri="")
+        self.sipConfig = types.SimpleNamespace(authCreds=[])
+        self.mediaConfig = types.SimpleNamespace()
+        self.natConfig = types.SimpleNamespace(
+            iceEnabled=False,
+            turnEnabled=False,
+            stunServer="",
+            turnServer="",
+            turnUserName="",
+            turnPassword="",
+        )
+
+
+class _FakeTransportConfig:
+    def __init__(self):
+        self.port = 0
+
+
+_fake_pj = types.ModuleType("pjsua2")
+_fake_pj.AudioMedia = _FakeAudioMedia
+_fake_pj.Call = _FakeCall
+_fake_pj.Account = _FakeAccount
+_fake_pj.Endpoint = _FakeEndpoint
+_fake_pj.EpConfig = _FakeEpConfig
+_fake_pj.AccountConfig = _FakeAccountConfig
+_fake_pj.TransportConfig = _FakeTransportConfig
+_fake_pj.CallOpParam = _FakeCallOpParam
+_fake_pj.TimerEntry = type("TimerEntry", (), {})
+_fake_pj.AuthCredInfo = lambda *args, **kwargs: types.SimpleNamespace(args=args, kwargs=kwargs)
+_fake_pj.TimeVal = _FakeTimeVal
+_fake_pj.PJMEDIA_FRAME_TYPE_AUDIO = 0
+_fake_pj.PJMEDIA_FRAME_TYPE_NONE = 1
+_fake_pj.PJSUA_INVALID_ID = -1
+_fake_pj.PJSIP_INV_STATE_CONFIRMED = 1
+_fake_pj.PJSIP_INV_STATE_DISCONNECTED = 2
+_fake_pj.PJSIP_ROLE_UAC = 3
+_fake_pj.PJSIP_TRANSPORT_UDP = 0
+_fake_pj.PJSUA_SRTP_DISABLED = 0
+_fake_pj.PJSUA_SRTP_OPTIONAL = 1
+_fake_pj.PJSUA_SRTP_MANDATORY = 2
+
+sys.modules.setdefault("pjsua2", _fake_pj)
+
+_fake_openai = types.ModuleType("openai")
+
+
+class _FakeOpenAI:
+    def __init__(self, api_key=None):
+        self.api_key = api_key
+
+
+_fake_openai.OpenAI = _FakeOpenAI
+sys.modules.setdefault("openai", _fake_openai)
+
+_fake_websockets = types.ModuleType("websockets")
+
+
+async def _fake_connect(*args, **kwargs):  # pragma: no cover - stub
+    raise RuntimeError("websockets.connect stub")
+
+
+_fake_websockets.connect = _fake_connect
+sys.modules.setdefault("websockets", _fake_websockets)
+
+_fake_flask = types.ModuleType("flask")
+
+
+class _FakeFlask:
+    def __init__(self, name):
+        self.name = name
+
+    def route(self, *args, **kwargs):  # pragma: no cover - stub
+        def decorator(func):
+            return func
+
+        return decorator
+
+
+_fake_flask.Flask = _FakeFlask
+_fake_flask.jsonify = lambda *args, **kwargs: {}
+_fake_flask.render_template_string = lambda *args, **kwargs: ""
+_fake_flask.request = types.SimpleNamespace(method="GET", form={}, json={})
+sys.modules.setdefault("flask", _fake_flask)
+
+_fake_dotenv = types.ModuleType("dotenv")
+_fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+sys.modules.setdefault("dotenv", _fake_dotenv)
+
+
+class _FakeMonitor:
+    def __init__(self):
+        self.logs = []
+
+    def add_log(self, message):  # pragma: no cover - stub
+        self.logs.append(message)
+
+    def remove_call(self, *args, **kwargs):  # pragma: no cover - stub
+        pass
+
+    def update_tokens(self, *args, **kwargs):  # pragma: no cover - stub
+        pass
+
+    def update_registration(self, *args, **kwargs):  # pragma: no cover - stub
+        pass
+
+    def start(self):  # pragma: no cover - stub
+        pass
+
+
+sys.modules.setdefault("monitor", types.SimpleNamespace(monitor=_FakeMonitor()))

--- a/tests/test_audio_pipeline.py
+++ b/tests/test_audio_pipeline.py
@@ -1,0 +1,183 @@
+import asyncio
+import base64
+import json
+import types
+import contextlib
+
+import app.agent as agent
+
+
+class DummyWriter:
+    def __init__(self):
+        self.calls = 0
+
+    async def drain(self):
+        self.calls += 1
+
+
+class DummyTransport:
+    def __init__(self):
+        self._closing = False
+
+    def is_closing(self):
+        return self._closing
+
+
+class DummyWebSocket:
+    def __init__(self, incoming=None):
+        self.sent = []
+        self.closed = False
+        self.transport = DummyTransport()
+        self._writer = DummyWriter()
+        self.connection = types.SimpleNamespace(
+            drain=self._writer.drain,
+            writer=self._writer,
+            _writer=self._writer,
+        )
+        self._incoming = asyncio.Queue()
+        if incoming:
+            for item in incoming:
+                self._incoming.put_nowait(item)
+
+    async def send(self, payload):
+        self.sent.append(payload)
+
+    async def recv(self):
+        return await self._incoming.get()
+
+    async def close(self, code=1000, reason=""):
+        self.closed = True
+        self.transport._closing = True
+
+    async def wait_closed(self):
+        return
+
+
+def test_audio_callback_frame_alignment():
+    async def main():
+        callback = agent.AudioCallback(call=None)
+        samples = bytes(range(256)) * 10
+        payload_length = agent.FRAME_BYTES * 2 + agent.FRAME_BYTES // 2
+        frame_payload = samples[:payload_length]
+        frame = types.SimpleNamespace(
+            type=agent.pj.PJMEDIA_FRAME_TYPE_AUDIO,
+            buf=frame_payload,
+        )
+        callback.putFrame(frame)
+
+        collected = [await asyncio.wait_for(callback.get_capture_frame(), timeout=0.1) for _ in range(2)]
+        assert all(len(chunk) == agent.FRAME_BYTES for chunk in collected)
+        assert len(callback._capture_buffer) == agent.FRAME_BYTES // 2
+
+    asyncio.run(main())
+
+
+def test_realtime_send_and_commit(monkeypatch):
+    async def main():
+        callback = agent.AudioCallback(call=None)
+        call = agent.Call.__new__(agent.Call)
+        call.audio_callback = callback
+        ws = DummyWebSocket()
+        call.ws = ws
+        call._realtime_input_committed = False
+
+        recorded_tokens = []
+        monkeypatch.setattr(agent.monitor, "update_tokens", recorded_tokens.append)
+
+        frame = b"\x01\x02" * (agent.FRAME_BYTES // 2)
+        callback.capture_queue.put_nowait(frame)
+        callback.capture_queue.put_nowait(frame)
+
+        async def stop_soon():
+            await asyncio.sleep(0.01)
+            callback.is_active = False
+
+        asyncio.create_task(stop_soon())
+        await call.send_audio_to_openai_realtime()
+
+        assert len(ws.sent) == 2
+        for payload in ws.sent:
+            message = json.loads(payload)
+            assert message["type"] == "input_audio_buffer.append"
+            assert base64.b64decode(message["audio"]) == frame
+        assert ws.connection.writer.calls == 2
+        assert call._realtime_input_committed is False
+        assert recorded_tokens == []
+
+        await call._send_realtime_commit()
+        assert call._realtime_input_committed is True
+        assert json.loads(ws.sent[-1]) == {"type": "input_audio_buffer.commit"}
+
+        await call._close_websocket()
+        assert ws.closed is True
+        assert call.ws is None
+
+    asyncio.run(main())
+
+
+def test_realtime_receive_streams_to_playback():
+    async def main():
+        callback = agent.AudioCallback(call=None)
+        call = agent.Call.__new__(agent.Call)
+        call.audio_callback = callback
+
+        frame = b"\x03\x04" * (agent.FRAME_BYTES // 2)
+        message = json.dumps({
+            "type": "response.output_audio.delta",
+            "delta": base64.b64encode(frame).decode("utf-8"),
+        })
+        ws = DummyWebSocket(incoming=[message])
+        call.ws = ws
+
+        task = asyncio.create_task(call.receive_audio_from_openai_realtime())
+        await asyncio.sleep(0.05)
+        assert not callback.playback_queue.empty()
+        queued = callback.playback_queue.get_nowait()
+        callback.playback_queue.task_done()
+        assert queued == frame
+
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    asyncio.run(main())
+
+
+def test_legacy_send_and_receive(monkeypatch):
+    async def main():
+        callback = agent.AudioCallback(call=None)
+        call = agent.Call.__new__(agent.Call)
+        call.audio_callback = callback
+
+        incoming_frame = b"\x05\x06" * (agent.FRAME_BYTES // 2)
+        ws = DummyWebSocket(incoming=[incoming_frame])
+        call.ws = ws
+
+        monkeypatch.setattr(agent.monitor, "update_tokens", lambda *args, **kwargs: None)
+
+        frame = b"\x07\x08" * (agent.FRAME_BYTES // 2)
+        callback.capture_queue.put_nowait(frame)
+
+        async def stop_later():
+            await asyncio.sleep(0.01)
+            callback.is_active = False
+
+        asyncio.create_task(stop_later())
+        send_task = asyncio.create_task(call.send_audio_to_openai_legacy())
+        recv_task = asyncio.create_task(call.receive_audio_from_openai_legacy())
+
+        await asyncio.sleep(0.05)
+        await send_task
+        assert ws.sent == [frame]
+        assert ws.connection.writer.calls == 1
+
+        assert not callback.playback_queue.empty()
+        queued = callback.playback_queue.get_nowait()
+        callback.playback_queue.task_done()
+        assert queued == incoming_frame
+
+        recv_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await recv_task
+
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- refactor the PJSIP audio callback to enforce 16 kHz 16-bit framing, apply bounded backpressure, and drive playback directly through the call media path
- update SIP call WebSocket handling to leverage flow control, commit realtime input buffers on hangup, and close sessions cleanly without lingering audio
- add asyncio-based unit tests with stubbed media/websocket layers to cover RTP ingestion plus realtime and legacy send/receive flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68caf6d4a454832dacd62c6198ccaa18