### PR TITLE
feat: add typed config and developer tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      SIP_DOMAIN: example.com
+      SIP_USER: "1001"
+      SIP_PASS: secret
+      OPENAI_API_KEY: test-key
+      AGENT_ID: test-agent
+      ENABLE_SIP: "true"
+      ENABLE_AUDIO: "true"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+      - name: Lint
+        run: make lint
+      - name: Type check
+        run: make type
+      - name: Tests
+        run: make test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.2
+    hooks:
+      - id: ruff-format
+      - id: ruff
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
+        additional_dependencies: []
+        args: ["--config-file", "mypy.ini", "app", "tests"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,17 @@ If you encounter unexpected behaviour or a defect:
    git checkout -b feature/your‑feature
    ```
 
-2. **Write code** that adheres to the following standards:
+2. **Set up the tooling** by installing the development dependencies and
+   pre-commit hooks:
+
+   ```bash
+   make dev
+   ```
+
+   This installs the packages listed in `requirements-dev.txt` and registers
+   the repository’s pre-commit hooks locally.
+
+3. **Write code** that adheres to the following standards:
 
    * Follow [PEP 8](https://peps.python.org/pep-0008/) for Python code style.
    * Document new functions, classes and modules with docstrings.
@@ -39,17 +49,28 @@ If you encounter unexpected behaviour or a defect:
    * Write tests where possible; although this project currently lacks a full
      test suite, contributions that include tests are appreciated.
 
-3. **Commit your changes** with clear messages:
+4. **Run the automated checks** before submitting your changes:
+
+   ```bash
+   make lint
+   make type
+   make test
+   ```
+
+   The lint target runs `ruff check`, the type target executes `mypy` with
+   `mypy.ini`, and the test target runs the `pytest` suite.
+
+5. **Commit your changes** with clear messages:
 
    ```bash
    git commit -m "feat: add support for XYZ"
    ```
 
-4. **Push** your branch to GitHub and open a pull request (PR).  In the PR
+6. **Push** your branch to GitHub and open a pull request (PR).  In the PR
    description, describe what you’ve done and reference any issues the PR
    resolves.
 
-5. **Address review feedback**.  We may request changes or clarifications.
+7. **Address review feedback**.  We may request changes or clarifications.
    Please be patient and respond to review comments.
 
 ## Code of Conduct

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+PYTHON ?= python3
+PIP ?= $(PYTHON) -m pip
+
+.PHONY: dev lint type test format pre-commit
+
+dev:
+	$(PIP) install --upgrade pip
+	$(PIP) install -r requirements-dev.txt
+	pre-commit install
+
+lint:
+	ruff check .
+
+type:
+	mypy --config-file mypy.ini app
+
+test:
+	pytest -q
+
+format:
+	ruff format .
+
+pre-commit:
+	pre-commit run --all-files

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ provide a more natural and expressive sound【214777425731610†L286-L314】.
    OPENAI_API_KEY=sk‑...
    AGENT_ID=va_123456789
 
+   # Runtime toggles
+   ENABLE_SIP=true
+   ENABLE_AUDIO=true
+
    # Choose API mode: legacy or realtime
    OPENAI_MODE=realtime
 
@@ -73,6 +77,13 @@ provide a more natural and expressive sound【214777425731610†L286-L314】.
    OPENAI_TEMPERATURE=0.3
    SYSTEM_PROMPT=You are a helpful voice assistant.
    ```
+
+   Set `ENABLE_SIP=false` to run only the monitoring dashboard without
+   registering to your PBX, or `ENABLE_AUDIO=false` to keep signalling active
+   while disabling the media bridge.  Configuration is validated on startup;
+   if any required variables are missing or malformed the agent exits with a
+   detailed error that lists the offending keys in both the console output and
+   the monitoring dashboard logs.
 
    When using realtime mode the agent sends a `session.update` message to
    OpenAI containing the model, voice, audio format (16‑bit PCM at 16 kHz)
@@ -188,10 +199,21 @@ it using the configured extension number.
 
 ## Development
 
-This project is containerized for ease of deployment, but if you want to
-develop locally you can install the dependencies listed in
-`requirements.txt` and run `python agent.py`.  The monitor will start on
-port 8080 by default.
+This project ships with a `Makefile` and pre-commit configuration to
+standardise local workflows.  To get started run:
+
+```bash
+make dev       # install runtime + development dependencies and configure pre-commit
+make lint      # ruff check .
+make type      # mypy static type analysis
+make test      # pytest -q
+make format    # apply ruff's formatter
+```
+
+The `requirements-dev.txt` file extends the runtime dependencies with the
+tooling used in CI.  You can still run `python app/agent.py` directly once
+your environment variables are configured; the monitor listens on port 8080
+by default.
 
 ### Contributing
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,244 @@
+"""Centralised configuration loading and validation utilities."""
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple, cast
+
+from pydantic import Field, ValidationError, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+ENV_FILE = BASE_DIR / ".env"
+
+
+class ConfigurationError(RuntimeError):
+    """Raised when the environment configuration cannot be validated."""
+
+    def __init__(self, message: str, *, details: List[str] | None = None):
+        super().__init__(message)
+        self.details: List[str] = details or []
+
+
+class Settings(BaseSettings):
+    """Typed representation of the agent configuration."""
+
+    model_config = SettingsConfigDict(
+        extra="ignore",
+        populate_by_name=True,
+        env_file=str(ENV_FILE),
+        env_file_encoding="utf-8",
+    )
+
+    sip_domain: str = Field(..., alias="SIP_DOMAIN", min_length=1)
+    sip_user: str = Field(..., alias="SIP_USER", min_length=1)
+    sip_pass: str = Field(..., alias="SIP_PASS", min_length=1)
+
+    openai_api_key: str = Field(..., alias="OPENAI_API_KEY", min_length=1)
+    agent_id: str = Field(..., alias="AGENT_ID", min_length=1)
+
+    openai_mode: str = Field("legacy", alias="OPENAI_MODE")
+    openai_model: str = Field("gpt-realtime", alias="OPENAI_MODEL")
+    openai_voice: str = Field("alloy", alias="OPENAI_VOICE")
+    openai_temperature: float = Field(0.3, alias="OPENAI_TEMPERATURE", ge=0.0, le=2.0)
+    system_prompt: str = Field(
+        "You are a helpful voice assistant.", alias="SYSTEM_PROMPT"
+    )
+
+    enable_sip: bool = Field(True, alias="ENABLE_SIP")
+    enable_audio: bool = Field(True, alias="ENABLE_AUDIO")
+
+    sip_transport_port: int = Field(5060, alias="SIP_TRANSPORT_PORT", ge=0, le=65535)
+    sip_jb_min: int = Field(0, alias="SIP_JB_MIN", ge=0)
+    sip_jb_max: int = Field(0, alias="SIP_JB_MAX", ge=0)
+    sip_jb_max_pre: int = Field(0, alias="SIP_JB_MAX_PRE", ge=0)
+    sip_enable_ice: bool = Field(False, alias="SIP_ENABLE_ICE")
+    sip_enable_turn: bool = Field(False, alias="SIP_ENABLE_TURN")
+    sip_stun_server: str | None = Field(None, alias="SIP_STUN_SERVER")
+    sip_turn_server: str | None = Field(None, alias="SIP_TURN_SERVER")
+    sip_turn_user: str | None = Field(None, alias="SIP_TURN_USER")
+    sip_turn_pass: str | None = Field(None, alias="SIP_TURN_PASS")
+    sip_enable_srtp: bool = Field(False, alias="SIP_ENABLE_SRTP")
+    sip_srtp_optional: bool = Field(True, alias="SIP_SRTP_OPTIONAL")
+    sip_preferred_codecs: Tuple[str, ...] = Field(
+        (), alias="SIP_PREFERRED_CODECS"
+    )
+
+    sip_reg_retry_base: float = Field(2.0, alias="SIP_REG_RETRY_BASE", ge=0.0)
+    sip_reg_retry_max: float = Field(60.0, alias="SIP_REG_RETRY_MAX", ge=0.0)
+    sip_invite_retry_base: float = Field(1.0, alias="SIP_INVITE_RETRY_BASE", ge=0.0)
+    sip_invite_retry_max: float = Field(30.0, alias="SIP_INVITE_RETRY_MAX", ge=0.0)
+    sip_invite_max_attempts: int = Field(5, alias="SIP_INVITE_MAX_ATTEMPTS", ge=0)
+
+    @field_validator(
+        "sip_domain",
+        "sip_user",
+        "sip_pass",
+        "openai_api_key",
+        "agent_id",
+        mode="before",
+    )
+    @classmethod
+    def _strip_and_validate_required(cls, value: object) -> object:
+        if value is None:
+            return value
+        text = str(value).strip()
+        if not text:
+            raise ValueError("must not be empty")
+        return text
+
+    @field_validator(
+        "openai_mode",
+        mode="before",
+    )
+    @classmethod
+    def _normalise_mode(cls, value: object) -> object:
+        if isinstance(value, str):
+            return value.lower()
+        return value
+
+    @field_validator(
+        "sip_stun_server",
+        "sip_turn_server",
+        "sip_turn_user",
+        "sip_turn_pass",
+        mode="before",
+    )
+    @classmethod
+    def _blank_string_to_none(cls, value: object) -> object:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    @field_validator("sip_preferred_codecs", mode="before")
+    @classmethod
+    def _parse_codecs(cls, value: object) -> Tuple[str, ...]:
+        if value in (None, "", ()):  # type: ignore[comparison-overlap]
+            return ()
+        if isinstance(value, str):
+            items = [item.strip() for item in value.split(",")]
+            return tuple(item for item in items if item)
+        if isinstance(value, Iterable):
+            return tuple(str(item).strip() for item in value if str(item).strip())
+        raise TypeError("SIP_PREFERRED_CODECS must be a comma-separated string")
+
+    def as_env(self) -> Dict[str, str]:
+        """Return the configuration as ``KEY=value`` style strings."""
+
+        env: Dict[str, str] = {}
+        for field_name, field in self.model_fields.items():
+            alias = field.alias or field_name
+            value = getattr(self, field_name)
+            if value is None:
+                env[alias] = ""
+            elif isinstance(value, tuple):
+                env[alias] = ",".join(value)
+            elif isinstance(value, bool):
+                env[alias] = "true" if value else "false"
+            else:
+                env[alias] = str(value)
+        return env
+
+
+_FIELD_ALIAS: Dict[str, str] = {
+    name: field.alias or name for name, field in Settings.model_fields.items()
+}
+_ALIAS_FIELD: Dict[str, str] = {alias: name for name, alias in _FIELD_ALIAS.items()}
+
+
+def _format_validation_errors(exc: ValidationError) -> List[str]:
+    details: List[str] = []
+    for error in exc.errors():
+        if not error.get("loc"):
+            details.append(error.get("msg", "Invalid configuration"))
+            continue
+        field_name = str(error["loc"][-1])
+        alias = _FIELD_ALIAS.get(field_name, field_name)
+        details.append(f"{alias}: {error.get('msg', 'invalid value')}")
+    return details
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    """Load settings from the environment and ``.env`` file."""
+
+    try:
+        return Settings()  # type: ignore[call-arg]
+    except ValidationError as exc:  # pragma: no cover - exercised at runtime
+        details = _format_validation_errors(exc)
+        message = "Invalid environment configuration:\n" + "\n".join(
+            f"  - {item}" for item in details
+        )
+        raise ConfigurationError(message, details=details) from exc
+
+
+def env_file_path() -> Path:
+    """Return the path to the runtime ``.env`` file."""
+
+    return ENV_FILE
+
+
+def read_env_file(path: Path | None = None) -> Dict[str, str]:
+    """Read key/value pairs from ``path`` and return them as a dictionary."""
+
+    target = path or env_file_path()
+    if not target.exists():
+        return {}
+    data: Dict[str, str] = {}
+    for line in target.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if "=" in stripped:
+            key, value = stripped.split("=", 1)
+            data[key.strip()] = value.strip()
+    return data
+
+
+def merge_env(base: Dict[str, str], overrides: Dict[str, str]) -> Dict[str, str]:
+    """Merge two ``KEY=value`` mappings, returning a new dictionary."""
+
+    merged = dict(base)
+    for key, value in overrides.items():
+        merged[key] = "" if value is None else str(value)
+    return merged
+
+
+def validate_env_map(
+    values: Dict[str, str], *, include_os_environ: bool = False
+) -> Settings:
+    """Validate a raw mapping of environment variables."""
+
+    combined: Dict[str, str] = {}
+    if include_os_environ:
+        for key, value in os.environ.items():
+            if key in _ALIAS_FIELD and key not in values:
+                combined[key] = value
+    combined.update(values)
+    settings_payload = cast(
+        Dict[str, Any],
+        {
+            _ALIAS_FIELD[key]: combined[key]
+            for key in combined
+            if key in _ALIAS_FIELD
+        },
+    )
+    try:
+        return Settings(**settings_payload)
+    except ValidationError as exc:
+        details = _format_validation_errors(exc)
+        message = "Invalid environment configuration:\n" + "\n".join(
+            f"  - {item}" for item in details
+        )
+        raise ConfigurationError(message, details=details) from exc
+
+
+def write_env_file(values: Dict[str, str], path: Path | None = None) -> None:
+    """Persist ``values`` to ``path`` as ``KEY=value`` lines."""
+
+    target = path or env_file_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"{key}={value}" for key, value in sorted(values.items())]
+    target.write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/env.example
+++ b/env.example
@@ -3,6 +3,13 @@ SIP_USER=1001
 SIP_PASS=yourpassword
 OPENAI_API_KEY=sk-...
 AGENT_ID=va_...
+ENABLE_SIP=true
+ENABLE_AUDIO=true
+OPENAI_MODE=legacy
+OPENAI_MODEL=gpt-realtime
+OPENAI_VOICE=alloy
+OPENAI_TEMPERATURE=0.3
+SYSTEM_PROMPT=You are a helpful voice assistant.
 # Optional SIP media/network tuning
 SIP_TRANSPORT_PORT=5060
 SIP_JB_MIN=0

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+python_version = 3.11
+ignore_missing_imports = True
+warn_unused_configs = True
+
+[mypy-tests.*]
+disable_error_code = attr-defined,arg-type
+ignore_errors = True
+
+[mypy-tests]
+ignore_errors = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F"]
+ignore = ["E501"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "lf"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+pre-commit>=3.7,<4.0
+pytest>=7.4,<8.0
+mypy>=1.10,<1.11
+ruff>=0.5.2,<0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,9 @@ websockets==11.0.3
 # OpenAI API
 openai>=1.0.0
 
-# Environment variables
-python-dotenv==1.0.0
+# Configuration
+pydantic>=2.7,<3.0
+pydantic-settings>=2.2,<3.0
 
 # Monitoring
 flask==2.0.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import types
 from pathlib import Path
@@ -5,6 +6,19 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+_DEFAULT_ENV = {
+    "SIP_DOMAIN": "example.com",
+    "SIP_USER": "1001",
+    "SIP_PASS": "secret",
+    "OPENAI_API_KEY": "test-key",
+    "AGENT_ID": "test-agent",
+    "ENABLE_SIP": "true",
+    "ENABLE_AUDIO": "true",
+}
+
+for _key, _value in _DEFAULT_ENV.items():
+    os.environ.setdefault(_key, _value)
 
 
 class _FakeAudioMedia:
@@ -192,6 +206,7 @@ sys.modules.setdefault("flask", _fake_flask)
 
 _fake_dotenv = types.ModuleType("dotenv")
 _fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+_fake_dotenv.dotenv_values = lambda *args, **kwargs: {}
 sys.modules.setdefault("dotenv", _fake_dotenv)
 
 


### PR DESCRIPTION
## Summary
- introduce a pydantic-based configuration module that validates environment variables and exposes helper utilities for the monitor UI
- refactor the agent and monitor to consume the shared settings, support ENABLE_SIP/ENABLE_AUDIO toggles, and surface configuration errors
- add developer ergonomics including Makefile targets, pre-commit, CI workflow, and documentation updates

## Testing
- make lint
- make type
- make test

------
https://chatgpt.com/codex/tasks/task_b_68caffbde8f0832da5eb77d7764c832e