### PR TITLE
Add CLI tooling for configuration validation and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ If you encounter unexpected behaviour or a defect:
 
    ```bash
    make dev
+   make env-validate  # optional: confirm your .env satisfies the schema
    ```
 
    This installs the packages listed in `requirements-dev.txt` and registers
@@ -55,6 +56,7 @@ If you encounter unexpected behaviour or a defect:
    make lint
    make type
    make test
+   make env-validate
    ```
 
    The lint target runs `ruff check`, the type target executes `mypy` with

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 PYTHON ?= python3
 PIP ?= $(PYTHON) -m pip
+ENV_FILE ?= .env
+ENV_EXAMPLE ?= env.example
 
-.PHONY: dev lint type test format pre-commit
+.PHONY: dev lint type test format pre-commit env-validate env-sample
 
 dev:
 	$(PIP) install --upgrade pip
@@ -22,3 +24,9 @@ format:
 
 pre-commit:
 	pre-commit run --all-files
+
+env-validate:
+	$(PYTHON) -m app.config validate --path $(ENV_FILE)
+
+env-sample:
+	$(PYTHON) -m app.config sample --write --path $(ENV_EXAMPLE)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ provide a more natural and expressive sound【214777425731610†L286-L314】.
    detailed error that lists the offending keys in both the console output and
    the monitoring dashboard logs.
 
+   You can validate your `.env` file at any time using the built-in helper:
+
+   ```bash
+   python -m app.config validate --path .env
+   # or via make
+   make env-validate
+   ```
+
+   To regenerate the example configuration with the latest defaults, run:
+
+   ```bash
+   python -m app.config sample --write --path env.example
+   # or
+   make env-sample
+   ```
+
    When using realtime mode the agent sends a `session.update` message to
    OpenAI containing the model, voice, audio format (16‑bit PCM at 16 kHz)
    and system prompt【826943400076790†L230-L249】.  This ensures the session is
@@ -208,6 +224,8 @@ make lint      # ruff check .
 make type      # mypy static type analysis
 make test      # pytest -q
 make format    # apply ruff's formatter
+make env-validate  # validate .env against the pydantic schema
+make env-sample    # regenerate env.example from the canonical template
 ```
 
 The `requirements-dev.txt` file extends the runtime dependencies with the

--- a/env.example
+++ b/env.example
@@ -1,8 +1,13 @@
+# PBX
 SIP_DOMAIN=your.asterisk.ip.or.domain
 SIP_USER=1001
 SIP_PASS=yourpassword
+
+# OpenAI
 OPENAI_API_KEY=sk-...
 AGENT_ID=va_...
+
+# Runtime toggles
 ENABLE_SIP=true
 ENABLE_AUDIO=true
 OPENAI_MODE=legacy
@@ -10,6 +15,7 @@ OPENAI_MODEL=gpt-realtime
 OPENAI_VOICE=alloy
 OPENAI_TEMPERATURE=0.3
 SYSTEM_PROMPT=You are a helpful voice assistant.
+
 # Optional SIP media/network tuning
 SIP_TRANSPORT_PORT=5060
 SIP_JB_MIN=0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,80 @@
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from app import config
+
+
+@pytest.fixture()
+def valid_env(tmp_path: Path) -> Path:
+    lines = config.generate_env_example_lines()
+    path = tmp_path / ".env"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def test_validate_env_map_accepts_valid_values():
+    values = {
+        "SIP_DOMAIN": "example.com",
+        "SIP_USER": "1001",
+        "SIP_PASS": "secret",
+        "OPENAI_API_KEY": "sk-test",
+        "AGENT_ID": "va_test",
+    }
+    settings = config.validate_env_map(values)
+    assert settings.sip_domain == "example.com"
+    assert settings.enable_sip is True
+
+
+def test_validate_env_map_raises_for_bad_values():
+    with pytest.raises(config.ConfigurationError) as excinfo:
+        config.validate_env_map({"SIP_TRANSPORT_PORT": "not-a-number"})
+    assert "SIP_TRANSPORT_PORT" in "\n".join(excinfo.value.details)
+
+
+def test_generate_env_example_lines_structure():
+    lines = config.generate_env_example_lines()
+    assert lines[0] == "# PBX"
+    assert "SIP_DOMAIN=your.asterisk.ip.or.domain" in lines
+    comment_count = sum(1 for line in lines if line.startswith("#"))
+    assert lines.count("") == max(comment_count - 1, 0)
+
+
+def test_cli_validate_success(valid_env: Path, capsys):
+    exit_code = config.main(["validate", "--path", str(valid_env)])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert f"{valid_env}" in captured.out
+
+
+def test_cli_validate_failure(tmp_path: Path, capsys):
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        textwrap.dedent(
+            """
+            SIP_DOMAIN=example.com
+            SIP_USER=1001
+            SIP_PASS=secret
+            OPENAI_API_KEY=sk-test
+            AGENT_ID=va_test
+            SIP_TRANSPORT_PORT=not-a-number
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    exit_code = config.main(["validate", "--path", str(env_path)])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Invalid environment configuration" in captured.err
+    assert "SIP_TRANSPORT_PORT" in captured.err
+
+
+def test_cli_sample_write(tmp_path: Path, capsys):
+    example_path = tmp_path / "env.sample"
+    exit_code = config.main(["sample", "--write", "--path", str(example_path), "--no-print"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert example_path.read_text(encoding="utf-8") == ("\n".join(config.generate_env_example_lines()) + "\n")
+    assert "Sample environment written" in captured.out


### PR DESCRIPTION
## Summary
- extend `app.config` with CLI helpers to validate `.env` files and regenerate the canonical example
- add sample-generation utilities, Makefile targets, and refresh `env.example`
- update developer documentation and add tests covering the configuration helpers

## Testing
- pytest -q
- ruff check .
- mypy --config-file mypy.ini app

------
https://chatgpt.com/codex/tasks/task_b_68cb060c4c44832d92688beee30d8584