### PR TITLE
docs: expand SIP troubleshooting and config guidance

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -33,7 +33,7 @@ _ENV_EXAMPLE_TEMPLATE: List[Tuple[str | None, Dict[str, str]]] = [
         },
     ),
     (
-        "# Runtime toggles",
+        "# Feature toggles & realtime session",
         {
             "ENABLE_SIP": "true",
             "ENABLE_AUDIO": "true",
@@ -45,12 +45,18 @@ _ENV_EXAMPLE_TEMPLATE: List[Tuple[str | None, Dict[str, str]]] = [
         },
     ),
     (
-        "# Optional SIP media/network tuning",
+        "# Audio pipeline",
         {
             "SIP_TRANSPORT_PORT": "5060",
+            "SIP_PREFERRED_CODECS": "PCMU,PCMA,opus",
             "SIP_JB_MIN": "0",
             "SIP_JB_MAX": "0",
             "SIP_JB_MAX_PRE": "0",
+        },
+    ),
+    (
+        "# NAT traversal & media security",
+        {
             "SIP_ENABLE_ICE": "false",
             "SIP_ENABLE_TURN": "false",
             "SIP_STUN_SERVER": "",
@@ -59,7 +65,6 @@ _ENV_EXAMPLE_TEMPLATE: List[Tuple[str | None, Dict[str, str]]] = [
             "SIP_TURN_PASS": "",
             "SIP_ENABLE_SRTP": "false",
             "SIP_SRTP_OPTIONAL": "true",
-            "SIP_PREFERRED_CODECS": "PCMU,PCMA,opus",
         },
     ),
     (

--- a/env.example
+++ b/env.example
@@ -7,7 +7,7 @@ SIP_PASS=yourpassword
 OPENAI_API_KEY=sk-...
 AGENT_ID=va_...
 
-# Runtime toggles
+# Feature toggles & realtime session
 ENABLE_SIP=true
 ENABLE_AUDIO=true
 OPENAI_MODE=legacy
@@ -16,11 +16,14 @@ OPENAI_VOICE=alloy
 OPENAI_TEMPERATURE=0.3
 SYSTEM_PROMPT=You are a helpful voice assistant.
 
-# Optional SIP media/network tuning
+# Audio pipeline
 SIP_TRANSPORT_PORT=5060
+SIP_PREFERRED_CODECS=PCMU,PCMA,opus
 SIP_JB_MIN=0
 SIP_JB_MAX=0
 SIP_JB_MAX_PRE=0
+
+# NAT traversal & media security
 SIP_ENABLE_ICE=false
 SIP_ENABLE_TURN=false
 SIP_STUN_SERVER=
@@ -29,7 +32,6 @@ SIP_TURN_USER=
 SIP_TURN_PASS=
 SIP_ENABLE_SRTP=false
 SIP_SRTP_OPTIONAL=true
-SIP_PREFERRED_CODECS=PCMU,PCMA,opus
 
 # Retry behaviour (seconds)
 SIP_REG_RETRY_BASE=2.0


### PR DESCRIPTION
## Summary
- reorganize the configuration reference in the README to cover realtime session options, audio pipeline tuning, NAT/SRTP controls, and retry backoff settings
- add SIP failure mode guidance, firewall/NAT/SRTP operations notes, and troubleshooting tips tied to metrics/logs and the new audio pipeline tests
- align env.example and the sample generator with the new configuration sections

## Testing
- python -m app.config sample --write --path env.example

------
https://chatgpt.com/codex/tasks/task_b_68cb0a2559a4832da0d89b41c02b93f7