### PR TITLE
Add helper to build pjsua2 bindings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,25 +14,13 @@ RUN apt-get update && apt-get install -y \
     ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
-# Install PJSIP and pjsua2
-RUN cd /tmp && \
-    wget https://github.com/pjsip/pjproject/archive/2.12.tar.gz && \
-    tar -xzf 2.12.tar.gz && \
-    cd pjproject-2.12 && \
-    ./configure --enable-shared && \
-    make dep && \
-    make && \
-    make install && \
-    ldconfig && \
-    cd pjsip-apps/src/swig && \
-    make python && \
-    cd python && \
-    python setup.py install
+# Install PJSIP and pjsua2 bindings using the helper script
+COPY scripts/install_pjsua2.py scripts/install_pjsua2.py
+RUN python scripts/install_pjsua2.py
 
 # Install other Python packages
 COPY requirements.txt .
-RUN sed -i '/pjsua2==2.12/d' requirements.txt && \
-    pip install --no-cache-dir -r requirements.txt && \
+RUN pip install --no-cache-dir -r requirements.txt && \
     pip install --no-cache-dir "werkzeug<3.0.0" "flask<3.0.0"
 
 # Copy application code

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,12 @@ PIP ?= $(PYTHON) -m pip
 ENV_FILE ?= .env
 ENV_EXAMPLE ?= env.example
 
-.PHONY: dev lint type test format pre-commit env-validate env-sample
+.PHONY: install dev lint type test format pre-commit env-validate env-sample
+
+install:
+	$(PIP) install --upgrade pip
+	$(PIP) install -r requirements.txt
+	$(PYTHON) scripts/install_pjsua2.py
 
 dev:
 	$(PIP) install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -163,20 +163,39 @@ increase jitter buffers for choppy links or prioritise wideband codecs.  The
 monitoring dashboard exposes every field so you can experiment at runtime; when
 a value is cleared the agent falls back to the safe defaults shown above.
 
-3. **Build and start the container**
+3. **Install dependencies for local development (optional)**
+
+   To run the agent directly on your machine (or in CI) install the Python
+   requirements and then invoke the helper script that builds the PJSIP
+   libraries and `pjsua2` bindings:
+
+   ```bash
+   pip install -r requirements.txt
+   python scripts/install_pjsua2.py
+   # or use the bundled make target
+   make install
+   ```
+
+   The installer downloads `pjproject` 2.12, compiles it with
+   `--enable-shared`, builds the `pjsua2` Python module and installs it into
+   the active interpreter—the same sequence executed inside the Docker image.
+   Ensure the required system packages (`build-essential`, `libpcap-dev`,
+   `portaudio19-dev`, `python3-dev`, `swig`, etc.) are available on your host.
+
+4. **Build and start the container**
 
    ```bash
    docker compose up --build
    ```
 
-   This pulls the dependencies, builds PJSIP and starts the agent.  The
-   container exposes the following ports:
+   This pulls the dependencies, runs the shared installer for PJSIP and starts
+   the agent.  The container exposes the following ports:
 
    * `8080/tcp` — monitoring dashboard
    * `5060/udp` — SIP signalling
    * `16000–16100/udp` — RTP media
 
-4. **Access the dashboard**
+5. **Access the dashboard**
 
    Open your browser to `http://<docker-host>:8080`.  The home page shows the
    current registration state, active calls, token usage and a log view.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # SIP client dependencies
-pjsua2==2.12
 pyaudio==0.2.13
 pydub==0.25.1
 websockets==11.0.3

--- a/scripts/install_pjsua2.py
+++ b/scripts/install_pjsua2.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Build and install the pjsua2 Python bindings."""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+from urllib.request import urlretrieve
+
+PJSIP_VERSION = "2.12"
+PJSIP_URL = f"https://github.com/pjsip/pjproject/archive/{PJSIP_VERSION}.tar.gz"
+
+
+def run_command(command: list[str], *, cwd: Path | None = None) -> None:
+    """Run a subprocess command, echoing it to stdout."""
+    display_cmd = " ".join(command)
+    if cwd:
+        print(f"[install_pjsua2] $ (cd {cwd} && {display_cmd})")
+    else:
+        print(f"[install_pjsua2] $ {display_cmd}")
+    subprocess.run(command, check=True, cwd=cwd)
+
+
+def ldconfig_available() -> bool:
+    """Return True if ldconfig is available on this system."""
+    return shutil.which("ldconfig") is not None
+
+
+def running_as_root() -> bool:
+    """Detect whether the current user is root (Unix-only)."""
+    geteuid = getattr(os, "geteuid", None)
+    if geteuid is None:
+        return False
+    return geteuid() == 0
+
+
+def ensure_ld_library_path(prefix: Path | None) -> None:
+    """Emit guidance when shared libraries are installed to a custom prefix."""
+    if not prefix:
+        return
+
+    lib_dir = prefix / "lib"
+    if not ldconfig_available():
+        print(
+            "[install_pjsua2] ldconfig not found; ensure your runtime linker can "
+            "locate libraries under "
+            f"{lib_dir} (e.g. by exporting LD_LIBRARY_PATH)."
+        )
+    elif not running_as_root():
+        print(
+            "[install_pjsua2] ldconfig requires elevated privileges. If you "
+            "installed to a custom prefix, run ldconfig manually or update "
+            f"LD_LIBRARY_PATH to include {lib_dir}."
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build and install pjsua2 bindings from pjproject")
+    parser.add_argument(
+        "--prefix",
+        type=Path,
+        default=None,
+        help="Installation prefix to pass to configure. Defaults to system prefix.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Build even if pjsua2 is already importable.",
+    )
+    return parser.parse_args()
+
+
+def pjsua2_already_installed() -> bool:
+    try:
+        import pjsua2  # type: ignore
+    except ImportError:
+        return False
+    else:
+        location = getattr(pjsua2, "__file__", "<unknown>")
+        print(f"[install_pjsua2] Existing pjsua2 module detected at {location}.")
+        return True
+
+
+def build_and_install(prefix: Path | None) -> None:
+    with tempfile.TemporaryDirectory(prefix="pjproject-") as tmpdir_str:
+        tmpdir = Path(tmpdir_str)
+        archive_path = tmpdir / "pjproject.tar.gz"
+        print(f"[install_pjsua2] Downloading pjproject {PJSIP_VERSION} from {PJSIP_URL}...")
+        urlretrieve(PJSIP_URL, archive_path)
+
+        print(f"[install_pjsua2] Extracting to {tmpdir}...")
+        with tarfile.open(archive_path) as tar:
+            tar.extractall(path=tmpdir)
+
+        source_dir = tmpdir / f"pjproject-{PJSIP_VERSION}"
+        if not source_dir.exists():
+            raise RuntimeError(f"Extracted source directory {source_dir} not found")
+
+        configure_cmd = ["./configure", "--enable-shared"]
+        if prefix:
+            configure_cmd.append(f"--prefix={prefix}")
+        run_command(configure_cmd, cwd=source_dir)
+        run_command(["make", "dep"], cwd=source_dir)
+        run_command(["make"], cwd=source_dir)
+        run_command(["make", "install"], cwd=source_dir)
+
+        if ldconfig_available() and running_as_root():
+            run_command(["ldconfig"])
+        else:
+            ensure_ld_library_path(prefix)
+
+        swig_dir = source_dir / "pjsip-apps" / "src" / "swig"
+        run_command(["make", "python"], cwd=swig_dir)
+
+        python_dir = swig_dir / "python"
+        run_command([sys.executable, "setup.py", "install"], cwd=python_dir)
+
+    print("[install_pjsua2] Installation complete.")
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.force and pjsua2_already_installed():
+        print("[install_pjsua2] Skipping build; rerun with --force to rebuild.")
+        return
+
+    build_and_install(args.prefix)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a reusable scripts/install_pjsua2.py helper that builds pjproject 2.12 and installs the pjsua2 bindings
- wire the helper into local and container installs via a Makefile target and Dockerfile reuse
- document the streamlined install flow and remove the direct pjsua2 requirement

## Testing
- ruff check scripts/install_pjsua2.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68cb10713130832dbc8b14e75ff4debc