### PR TITLE
Add multi-stage Docker build for dashboard and expose web service

### DIFF
--- a/deploy/nginx/default.conf
+++ b/deploy/nginx/default.conf
@@ -1,0 +1,69 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Proxy API requests to the FastAPI monitor running in the agent container
+    location /api/ {
+        proxy_pass http://sip-agent:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Proxy WebSocket connections for live updates
+    location /ws/ {
+        proxy_pass http://sip-agent:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+    }
+
+    # Allow access to health and metrics endpoints through the proxy
+    location /metrics {
+        proxy_pass http://sip-agent:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /healthz {
+        proxy_pass http://sip-agent:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Forward authentication routes to the FastAPI app
+    location /login {
+        proxy_pass http://sip-agent:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /logout {
+        proxy_pass http://sip-agent:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Serve the single page app for everything else
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: backend
     container_name: sip-ai-agent
     restart: unless-stopped
     volumes:
@@ -10,6 +11,17 @@ services:
     env_file:
       - .env
     ports:
-      - "8080:8080"
       - "5060:5060/udp"
       - "16000-16100:16000-16100/udp"
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: dashboard
+    container_name: sip-ai-dashboard
+    depends_on:
+      - sip-agent
+    restart: unless-stopped
+    ports:
+      - "8080:80"


### PR DESCRIPTION
## Summary
- build the React/Tailwind dashboard during the Docker build so the FastAPI image always ships with fresh static assets
- add an nginx-based dashboard stage and expose it via a new `web` service in docker-compose with port 8080 proxying to the agent
- update the README to document the two-service setup and the new asset build flow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cc28b78830832d86d0fdfc3ba66a7e