### PR TITLE
Update CI workflow with frontend checks and image publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
+    tags:
+      - "v*"
   pull_request:
 
 jobs:
@@ -40,3 +42,51 @@ jobs:
         run: make type
       - name: Tests
         run: make test
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+      - name: Install frontend dependencies
+        working-directory: web
+        run: npm ci
+      - name: Lint frontend
+        working-directory: web
+        run: npm run lint
+      - name: Test frontend
+        working-directory: web
+        run: npm run test
+      - name: Log in to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Set latest tag
+        if: github.ref == 'refs/heads/main'
+        run: |
+          echo "BACKEND_LATEST_TAG=ghcr.io/${{ github.repository_owner }}/sip-ai-agent-backend:latest" >> $GITHUB_ENV
+          echo "DASHBOARD_LATEST_TAG=ghcr.io/${{ github.repository_owner }}/sip-ai-agent-dashboard:latest" >> $GITHUB_ENV
+      - name: Build and push backend image
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          target: backend
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/sip-ai-agent-backend:${{ github.sha }}
+            ${{ env.BACKEND_LATEST_TAG }}
+      - name: Build and push dashboard image
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          target: dashboard
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/sip-ai-agent-dashboard:${{ github.sha }}
+            ${{ env.DASHBOARD_LATEST_TAG }}


### PR DESCRIPTION
## Summary
- extend CI triggers to include release tags and add Node setup with frontend lint/test execution
- authenticate with GHCR and build/push backend and dashboard Docker targets tagged by commit SHA and latest on main

## Testing
- no tests were run (workflow configuration change)


------
https://chatgpt.com/codex/tasks/task_b_68cc38994c4c832d992c89ebd3612dfb