### PR TITLE
Replace placeholder citations with documentation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,9 @@ are given in UTC.
   switch between the legacy `/v1/audio/speech` API and OpenAI’s new
   realtime API.  The realtime API streams audio in both directions and
   eliminates the latency associated with converting speech to text and back
-  again【878443186554662†L53-L66】.  Support for new voices like Cedar and Marin
-  was added【214777425731610†L286-L314】.
+  again.  Support for new voices like Cedar and Marin was added to provide
+  more natural call experiences, in line with the [OpenAI realtime API
+  guide](https://platform.openai.com/docs/guides/realtime_api).
 * **Asynchronous audio handling.**  Refactored the agent to use
   `asyncio` for WebSocket and audio streaming, improving performance.
 * **Monitoring server.**  Added a simple Flask monitor to display SIP

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ both the legacy `/v1/audio/speech` WebSocket API and the newer realtime API
 for ultra‑low‑latency speech‑to‑speech interactions.  When `OPENAI_MODE` is
 set to `realtime`, audio from the caller is streamed directly to OpenAI and
 responses are streamed back as audio deltas, eliminating the need to convert
-speech to text and back and dramatically reducing latency【878443186554662†L53-L66】.  The
-realtime API also introduces new voices such as **Cedar** and **Marin** which
-provide a more natural and expressive sound【214777425731610†L286-L314】.
+speech to text and back and dramatically reducing latency.  The realtime API
+also introduces new voices such as **Cedar** and **Marin**, providing a more
+natural and expressive sound as documented in the [OpenAI realtime API
+guide](https://platform.openai.com/docs/guides/realtime_api).
 
 ### Features
 
@@ -21,7 +22,7 @@ provide a more natural and expressive sound【214777425731610†L286-L314】.
 * **Realtime API support** for low‑latency speech‑to‑speech conversations.
   The agent sends a `session.update` message on connection specifying the
   model, voice, audio formats and system instructions as recommended in
-  OpenAI’s documentation【826943400076790†L230-L249】.
+  [OpenAI’s realtime API guide](https://platform.openai.com/docs/guides/realtime_api).
 * **Asynchronous architecture** using `asyncio` for efficient audio and
   WebSocket handling.
 * **Web dashboard** displaying SIP registration state, active calls, token
@@ -36,7 +37,8 @@ provide a more natural and expressive sound【214777425731610†L286-L314】.
   for the agent.
 * Docker and Docker Compose.
 * An OpenAI API key.  If you plan to use the realtime API, ensure your
-  key has access to the `gpt‑realtime` model【214777425731610†L286-L314】.
+  key has access to the `gpt‑realtime` model; see the [OpenAI model
+  reference](https://platform.openai.com/docs/models).
 
 ## Installation
 
@@ -103,8 +105,9 @@ provide a more natural and expressive sound【214777425731610†L286-L314】.
 
    When using realtime mode the agent sends a `session.update` message to
    OpenAI containing the model, voice, audio format (16‑bit PCM at 16 kHz)
-   and system prompt【826943400076790†L230-L249】.  This ensures the session is
-   configured correctly before audio streaming begins.
+   and system prompt, as described in the [OpenAI realtime API
+   guide](https://platform.openai.com/docs/guides/realtime_api).  This ensures
+   the session is configured correctly before audio streaming begins.
 
 ### Advanced SIP configuration
 


### PR DESCRIPTION
## Summary
- rewrite README overview, features, requirements, and configuration notes to remove placeholder citation markers and reference the realtime API documentation directly
- update the 2.0.0 changelog entry with natural prose and a documentation link for the realtime API voices

## Testing
- make format

------
https://chatgpt.com/codex/tasks/task_b_68cc3ca5c2fc832d88e7439cf76023b3