### PR TITLE
Update README clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ guide](https://platform.openai.com/docs/guides/realtime_api).
 1. **Clone the repository**
 
    ```bash
-   git clone https://github.com/your‑org/openai‑sip‑agent.git
-   cd openai‑sip‑agent
+   git clone https://github.com/openai/sip-ai-agent.git
+   cd sip-ai-agent
    ```
 
 2. **Configure the environment**


### PR DESCRIPTION
## Summary
- update the README clone command to use the sip-ai-agent GitHub repository
- adjust the change directory step to match the actual repository name

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68cc3e0b29ac832db7289bfe49de2c98