### PR TITLE
Remove unused OpenAI client initialization

### DIFF
--- a/app/agent.py
+++ b/app/agent.py
@@ -9,7 +9,6 @@ import base64
 import queue
 import contextlib
 from typing import Optional, TYPE_CHECKING
-from openai import OpenAI
 import pjsua2 as pj
 
 try:
@@ -184,8 +183,6 @@ class EndpointTimer(pj.TimerEntry):
     def onTimeout(self) -> None:  # pragma: no cover - invoked by PJSIP runtime
         self._callback()
 
-# Initialize OpenAI client
-client = OpenAI(api_key=OPENAI_API_KEY or None)
 
 # Audio callback class for PJSIP
 class AudioCallback(pj.AudioMedia):


### PR DESCRIPTION
## Summary
- remove the unused OpenAI client import and initialization from `app/agent.py`

## Testing
- make lint

------
https://chatgpt.com/codex/tasks/task_b_68cc3ed1ba20832d996ab20dd373714a