### PR TITLE
Fix frontend build and vitest configuration

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 pre-commit>=3.7,<4.0
 pytest>=7.4,<8.0
+pytest-cov>=4.1,<5.0
 mypy>=1.10,<1.11
 ruff>=0.5.2,<0.6

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.4.0",
+        "jest-junit": "^16.0.0",
         "jsdom": "^27.0.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.15",
@@ -3565,6 +3566,45 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jest-junit": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
+      "integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^8.3.2",
+        "xml": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/jest-junit/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-junit/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -3846,6 +3886,19 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -5201,6 +5254,16 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/vite": {
       "version": "7.1.6",
@@ -6623,6 +6686,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest --run"
+    "test": "node ./scripts/run-vitest.mjs"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
@@ -24,6 +24,7 @@
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.2",
     "autoprefixer": "^10.4.21",
+    "jest-junit": "^16.0.0",
     "eslint": "^9.35.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",

--- a/web/scripts/run-vitest.mjs
+++ b/web/scripts/run-vitest.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const argv = process.argv.slice(2);
+const filteredArgs = [];
+for (let index = 0; index < argv.length; index += 1) {
+  const arg = argv[index];
+  if (arg === "--ci" || arg.startsWith("--ci=")) {
+    continue;
+  }
+  if (arg === "--reporters") {
+    const value = argv[index + 1];
+    if (value && !value.startsWith("-")) {
+      filteredArgs.push("--reporter", value);
+      index += 1;
+      continue;
+    }
+    continue;
+  }
+  if (arg.startsWith("--reporters=")) {
+    const value = arg.slice("--reporters=".length);
+    if (value.length > 0) {
+      filteredArgs.push(`--reporter=${value}`);
+    }
+    continue;
+  }
+  filteredArgs.push(arg);
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const vitestBin = resolve(__dirname, "../node_modules/.bin/vitest");
+
+const child = spawn(vitestBin, ["--run", ...filteredArgs], {
+  stdio: "inherit",
+  shell: process.platform === "win32",
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+  } else {
+    process.exit(code ?? 0);
+  }
+});
+
+child.on("error", (error) => {
+  console.error("Failed to start Vitest:", error);
+  process.exit(1);
+});

--- a/web/src/__tests__/dashboard-components.test.tsx
+++ b/web/src/__tests__/dashboard-components.test.tsx
@@ -55,9 +55,9 @@ afterEach(() => {
 
 describe('App dashboard integration', () => {
   it('renders mocked dashboard data and updates when the hook changes', () => {
-    const refresh = vi.fn<[], Promise<void>>().mockResolvedValue()
+    const refresh = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
     const saveConfig = vi
-      .fn<[ConfigMap], Promise<ConfigUpdateResponse>>()
+      .fn<(values: ConfigMap) => Promise<ConfigUpdateResponse>>()
       .mockResolvedValue({ success: true })
 
     const initialData: DashboardData = {
@@ -197,7 +197,7 @@ describe('ConfigEditor', () => {
     }
 
     const onSave = vi
-      .fn<[ConfigMap], Promise<ConfigUpdateResponse>>()
+      .fn<(values: ConfigMap) => Promise<ConfigUpdateResponse>>()
       .mockResolvedValue({ success: true })
     const user = userEvent.setup()
 
@@ -222,7 +222,7 @@ describe('ConfigEditor', () => {
   it('shows an error when saving fails', async () => {
     const config: ConfigMap = { SIP_DOMAIN: 'example.com' }
     const onSave = vi
-      .fn<[ConfigMap], Promise<ConfigUpdateResponse>>()
+      .fn<(values: ConfigMap) => Promise<ConfigUpdateResponse>>()
       .mockRejectedValue(new Error('Save failed'))
     const user = userEvent.setup()
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -10,11 +10,4 @@ export default defineConfig({
     emptyOutDir: true,
     sourcemap: false,
   },
-  test: {
-    environment: 'jsdom',
-    setupFiles: './src/test/setup.ts',
-    coverage: {
-      reporter: ['text', 'lcov'],
-    },
-  },
 })

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
+    coverage: {
+      reporter: ['text', 'lcov'],
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add a custom Vitest launcher that strips unsupported CI arguments before invoking the test runner
- update the web test script and dependencies so the pipeline can request JUnit output
- include pytest-cov in the development requirements so the backend test suite understands coverage flags
- adjust dashboard component tests to use the new Vitest mock generics so TypeScript can compile the suite
- move the Vitest options into a dedicated vitest.config.ts so the production Vite build no longer fails on unknown "test" settings

## Testing
- npm test -- --ci --reporters=default --reporters=jest-junit
- npm test
- npm run build
- pytest *(fails: missing optional dependencies such as pydantic and fastapi)*

------
https://chatgpt.com/codex/tasks/task_b_68cc4116d080832d9c1c6b60f75d86da