### PR TITLE
Add helper script for building GHCR-tagged images

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,32 @@ provide a more natural and expressive sound【214777425731610†L286-L314】.
    * `5060/udp` — SIP signalling
    * `16000–16100/udp` — RTP media
 
+## Building a commit-tagged container image
+
+Security and compliance tooling in this project expects a Docker image tagged
+with the current Git commit to be available locally as
+`ghcr.io/vaheed/sip-ai-agent-backend:sha-<commit>`.  The helper script
+[`scripts/build-image.sh`](scripts/build-image.sh) automates this by building
+the Dockerfile and tagging the result with both the commit SHA and `latest`.
+Run it from the repository root whenever you need a fresh image:
+
+```bash
+./scripts/build-image.sh
+```
+
+By default the image is tagged under `ghcr.io/vaheed/sip-ai-agent-backend` and
+uses the repository's current commit.  You can override these defaults by
+setting environment variables before invoking the script:
+
+```bash
+IMAGE_REGISTRY=my-registry.example.com/sip-agent \
+LATEST_TAG=dev ./scripts/build-image.sh abcd1234
+```
+
+After running the script the `sha-<commit>` tag will be available locally so
+tools such as Trivy can generate a SARIF report without attempting to pull the
+image from GHCR.
+
 4. **Access the dashboard**
 
    Open your browser to `http://<docker-host>:8080`.  The home page shows the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   sip-agent:
+    image: "${IMAGE_REGISTRY:-ghcr.io/vaheed/sip-ai-agent-backend}:${IMAGE_TAG:-latest}"
     build:
       context: .
       dockerfile: Dockerfile

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Default image registry path. Override with IMAGE_REGISTRY env var.
+IMAGE_REGISTRY=${IMAGE_REGISTRY:-ghcr.io/vaheed/sip-ai-agent-backend}
+
+# Determine Git commit SHA to embed in the image tag.
+if [[ $# -gt 0 && -n "${1:-}" ]]; then
+  GIT_SHA="$1"
+  shift
+elif git -C "$(dirname "${BASH_SOURCE[0]}")/.." rev-parse HEAD >/dev/null 2>&1; then
+  GIT_SHA=$(git -C "$(dirname "${BASH_SOURCE[0]}")/.." rev-parse HEAD)
+else
+  echo "Unable to determine git commit SHA. Pass it as the first argument." >&2
+  exit 1
+fi
+
+IMAGE_SHA_TAG="sha-${GIT_SHA}"
+LATEST_TAG=${LATEST_TAG:-latest}
+
+BUILD_CONTEXT=${BUILD_CONTEXT:-$(dirname "${BASH_SOURCE[0]}")/..}
+
+echo "Building Docker image ${IMAGE_REGISTRY}:${IMAGE_SHA_TAG}" >&2
+
+EXTRA_BUILD_ARGS=("$@")
+
+docker build \
+  "${EXTRA_BUILD_ARGS[@]}" \
+  -t "${IMAGE_REGISTRY}:${IMAGE_SHA_TAG}" \
+  -t "${IMAGE_REGISTRY}:${LATEST_TAG}" \
+  "${BUILD_CONTEXT}"


### PR DESCRIPTION
## Summary
- add a helper script that builds the Docker image and tags it with both the commit SHA and a configurable latest tag so scanners can find `ghcr.io/vaheed/sip-ai-agent-backend:sha-<commit>` locally
- document the new workflow in the README and explain how to override the registry or tags when building images
- configure docker-compose to tag local builds with the GHCR image name by default

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_b_68cc5392b554832d9fc7439ae927d820