### PR TITLE
Ensure Trivy image scans authenticate to GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,13 @@ jobs:
     needs: [build-and-push]
     if: github.event_name == 'push'
     steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
       - name: Trivy backend image
         uses: aquasecurity/trivy-action@0.24.0
         with:


### PR DESCRIPTION
## Summary
- log in to GHCR before running Trivy image scans so private images can be pulled

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68cc55627964832d9f567398e1980fab