### PR TITLE
Fix dashboard image tag in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
         id: meta_dashboard
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/sip-ai-agent-dashboard:latest
+          images: ghcr.io/${{ github.repository_owner }}/sip-ai-agent-dashboard
           tags: |
             type=sha
             type=ref,event=tag


### PR DESCRIPTION
## Summary
- fix the dashboard image name in the CI workflow so metadata-action produces valid tags

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_b_68cc657a72a4832d95530f05515acf33