### PR TITLE
Add production compose file using published images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
             docker:
               - 'Dockerfile'
               - 'docker-compose.yml'
+              - 'docker-compose.production.yml'
               - 'deploy/**'
             workflow:
               - '.github/workflows/**'

--- a/README.md
+++ b/README.md
@@ -199,6 +199,19 @@ a value is cleared the agent falls back to the safe defaults shown above.
    * `5060/udp` — SIP signalling handled by the `sip-agent` service
    * `16000–16100/udp` — RTP media relayed by the `sip-agent` service
 
+   To reuse the published images from the GitHub Container Registry instead of
+   building locally, run the production compose file:
+
+   ```bash
+   docker compose -f docker-compose.production.yml up -d
+   ```
+
+   By default this pulls `ghcr.io/openai/sip-ai-agent-backend:latest` for the
+   agent and `ghcr.io/openai/sip-ai-agent-dashboard:latest` for the dashboard.
+   Override the images by exporting `SIP_AGENT_IMAGE` or
+   `SIP_DASHBOARD_IMAGE` before running the command if you want to pin a
+   specific tag.
+
 5. **Access the dashboard**
 
    Open your browser to `http://<docker-host>:8080`.  The home page shows the

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,19 @@
+services:
+  sip-agent:
+    image: ${SIP_AGENT_IMAGE:-ghcr.io/openai/sip-ai-agent-backend:latest}
+    container_name: sip-ai-agent
+    restart: unless-stopped
+    env_file:
+      - .env
+    ports:
+      - "5060:5060/udp"
+      - "16000-16100:16000-16100/udp"
+
+  web:
+    image: ${SIP_DASHBOARD_IMAGE:-ghcr.io/openai/sip-ai-agent-dashboard:latest}
+    container_name: sip-ai-dashboard
+    depends_on:
+      - sip-agent
+    restart: unless-stopped
+    ports:
+      - "8080:80"


### PR DESCRIPTION
## Summary
- add a production docker compose file that uses the published backend and dashboard images
- document how to launch the stack with the pre-built images and override tags
- ensure CI treats changes to the production compose file as docker-related updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cc675821bc832dae7ef5376ae19ec2