### PR TITLE
Update backend Docker image to Python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm ci
 COPY web/ ./
 RUN npm run build
 
-FROM python:3.9-slim AS backend
+FROM python:3.11-slim AS backend
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- switch the backend container base image to python:3.11-slim to align with the project's Python version requirements

## Testing
- not run (docker CLI unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_b_68cd1ae56a64832dae87cc880917c943