### PR TITLE
Fix TimerEntry base class import in agent

### DIFF
--- a/app/agent.py
+++ b/app/agent.py
@@ -12,6 +12,11 @@ from typing import Callable, Optional, TYPE_CHECKING
 import pjsua2 as pj
 
 try:
+    from pjsua2 import TimerEntry as _TimerEntryBase
+except ImportError:  # pragma: no cover - fallback when direct import fails
+    _TimerEntryBase = getattr(pj, "TimerEntry", object)
+
+try:
     from .observability import (
         correlation_scope,
         generate_correlation_id,


### PR DESCRIPTION
## Summary
- ensure `EndpointTimer` has a concrete base class at runtime by importing `TimerEntry` from pjsua2 when available

## Testing
- pytest (fails: missing optional dependencies `pydantic` and `fastapi` in the test environment)


------
https://chatgpt.com/codex/tasks/task_b_68cd7d71bd24832daba5d25733ada38d