### PR TITLE
Ensure threading timer registers pjlib thread

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,6 +138,36 @@ class _FakeTransportConfig:
         self.port = 0
 
 
+class _FakeThreadDesc:
+    pass
+
+
+class _FakeThread:
+    pass
+
+
+class _FakeLib:
+    _instance = None
+
+    def __init__(self):
+        self.registered = []
+
+    @classmethod
+    def instance(cls):
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def threadRegister(self, name, desc=None, thread=None):  # pragma: no cover - stub
+        self.registered.append((name, desc, thread))
+
+    def threadIsRegistered(self):  # pragma: no cover - stub
+        return False
+
+    def reset(self):  # pragma: no cover - stub helper
+        self.registered.clear()
+
+
 _fake_pj = types.ModuleType("pjsua2")
 _fake_pj.AudioMedia = _FakeAudioMedia
 _fake_pj.Call = _FakeCall
@@ -150,6 +180,9 @@ _fake_pj.CallOpParam = _FakeCallOpParam
 _fake_pj.TimerEntry = type("TimerEntry", (), {})
 _fake_pj.AuthCredInfo = lambda *args, **kwargs: types.SimpleNamespace(args=args, kwargs=kwargs)
 _fake_pj.TimeVal = _FakeTimeVal
+_fake_pj.ThreadDesc = _FakeThreadDesc
+_fake_pj.Thread = _FakeThread
+_fake_pj.Lib = _FakeLib
 _fake_pj.PJMEDIA_FRAME_TYPE_AUDIO = 0
 _fake_pj.PJMEDIA_FRAME_TYPE_NONE = 1
 _fake_pj.PJSUA_INVALID_ID = -1

--- a/tests/test_endpoint_timer.py
+++ b/tests/test_endpoint_timer.py
@@ -1,0 +1,46 @@
+import types
+
+import pjsua2 as pj
+
+from app import agent
+from app.agent import EndpointTimer
+
+
+class _FailingEndpoint(types.SimpleNamespace):
+    def __init__(self):
+        super().__init__()
+        self.utilTimerSchedule = self._schedule
+        self.utilTimerCancel = lambda timer: None
+
+    def _schedule(self, timer, time_val):
+        raise RuntimeError("utilTimerSchedule not available")
+
+
+def test_endpoint_timer_registers_thread_on_fallback(monkeypatch):
+    lib = pj.Lib.instance()
+    if hasattr(lib, "reset"):
+        lib.reset()
+
+    callback_called = []
+
+    class _ImmediateTimer:
+        def __init__(self, delay, func):
+            self.delay = delay
+            self.func = func
+            self.daemon = False
+
+        def start(self):
+            self.func()
+
+        def cancel(self):
+            pass
+
+    monkeypatch.setattr(agent.threading, "Timer", _ImmediateTimer)
+
+    timer = EndpointTimer(_FailingEndpoint(), lambda: callback_called.append(True))
+    timer.schedule(0.5)
+
+    assert callback_called == [True]
+    assert getattr(lib, "registered", [])
+    name, *_ = lib.registered[-1]
+    assert name == "endpoint_timer"


### PR DESCRIPTION
## Summary
- ensure the EndpointTimer fallback registers a PJLIB thread before running callbacks when utilTimerSchedule is unavailable
- extend the pjsua2 test doubles and add coverage to confirm the fallback invokes thread registration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cd810bc8f8832dbcccddd2188a5558