### PR TITLE
Fix nginx routing for dashboard assets

### DIFF
--- a/deploy/nginx/default.conf
+++ b/deploy/nginx/default.conf
@@ -62,7 +62,18 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # Serve the single page app for everything else
+    # Redirect bare /dashboard path to include trailing slash
+    location = /dashboard {
+        return 302 /dashboard/;
+    }
+
+    # Serve the React dashboard under the /dashboard prefix
+    location /dashboard/ {
+        rewrite ^/dashboard/(.*)$ /$1 break;
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Serve the single page app for everything else (legacy paths/root access)
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
## Summary
- update the nginx configuration used by the dashboard container so that requests under `/dashboard/` are rewritten to the correct static asset paths
- keep `/dashboard` requests working by redirecting to `/dashboard/` while leaving the legacy `/` handler in place

## Testing
- No automated tests were run (configuration change only)

------
https://chatgpt.com/codex/tasks/task_b_68cd828f4c84832d80c2ae832f084f58