### PR TITLE
Redesign dashboard layout for responsive UI

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,24 +11,69 @@ import { ThemeToggle } from './components/ThemeToggle'
 import { useDashboardData } from './hooks/useDashboardData'
 
 const DashboardView = () => {
-  const { status, callHistory, logs, metrics, config, loading, authRequired, error, websocketState, refresh, saveConfig } =
-    useDashboardData()
+  const {
+    status,
+    callHistory,
+    logs,
+    metrics,
+    config,
+    loading,
+    authRequired,
+    error,
+    websocketState,
+    refresh,
+    saveConfig,
+  } = useDashboardData()
 
   if (authRequired) {
     return <AuthNotice />
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-100 via-white to-slate-200 pb-16 pt-10 dark:from-slate-950 dark:via-slate-900 dark:to-black">
-      <div className="mx-auto flex max-w-7xl flex-col gap-8 px-4 sm:px-6 lg:px-8">
-        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-50">SIP AI Agent Dashboard</h1>
-            <p className="mt-2 max-w-2xl text-sm text-gray-600 dark:text-gray-400">
-              Monitor SIP connectivity, live calls, and system logs in real time. Update configuration safely when needed.
-            </p>
+    <div className="relative min-h-screen overflow-hidden bg-slate-100 pb-16 pt-10 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute left-1/2 top-[-140px] h-[420px] w-[720px] -translate-x-1/2 rounded-full bg-blue-400/25 blur-[140px] dark:bg-blue-500/15" />
+        <div className="absolute -right-40 bottom-[-120px] h-[360px] w-[360px] rounded-full bg-emerald-300/30 blur-[140px] dark:bg-emerald-500/10" />
+        <div className="absolute -left-32 bottom-20 h-64 w-64 rounded-full bg-indigo-300/20 blur-[120px] dark:bg-indigo-500/10" />
+      </div>
+
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-4 sm:px-6 lg:px-8">
+        <header className="relative overflow-hidden rounded-3xl border border-white/60 bg-white/80 px-6 py-8 shadow-xl backdrop-blur dark:border-white/10 dark:bg-white/5 sm:px-10">
+          <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.18),_transparent_65%)] dark:bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.22),_transparent_70%)]" />
+          <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+            <div className="max-w-2xl space-y-4">
+              <span className="inline-flex items-center gap-2 rounded-full bg-blue-600/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-blue-600 dark:text-blue-300">
+                Realtime operations
+              </span>
+              <div className="space-y-3">
+                <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">SIP AI Agent Dashboard</h1>
+                <p className="text-sm text-slate-600 dark:text-slate-300">
+                  Monitor SIP connectivity, live calls, and system telemetry. Save configuration changes safely and stay on top of WebSocket health in one unified workspace.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-3 text-xs text-slate-500 dark:text-slate-400">
+                <span className="inline-flex items-center gap-1 rounded-full bg-slate-900/5 px-3 py-1 dark:bg-white/5">
+                  <span className="h-2 w-2 rounded-full bg-emerald-500" aria-hidden />
+                  Status insights auto-refresh
+                </span>
+                <span className="inline-flex items-center gap-1 rounded-full bg-slate-900/5 px-3 py-1 dark:bg-white/5">
+                  <span className="h-2 w-2 rounded-full bg-blue-500" aria-hidden />
+                  Secure configuration editing
+                </span>
+              </div>
+            </div>
+            <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-end md:w-auto md:flex-col">
+              <ThemeToggle />
+              <button
+                type="button"
+                onClick={refresh}
+                disabled={loading}
+                className="inline-flex items-center justify-center gap-2 rounded-full bg-blue-600 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300 dark:bg-blue-500 dark:hover:bg-blue-400"
+              >
+                {loading ? 'Refreshing…' : 'Refresh data'}
+              </button>
+            </div>
           </div>
-          <ThemeToggle />
         </header>
 
         {error ? <ErrorBanner message={error} onRetry={refresh} /> : null}
@@ -36,20 +81,17 @@ const DashboardView = () => {
         {loading ? (
           <LoadingScreen />
         ) : (
-          <div className="flex flex-col gap-8">
-            <StatusOverview status={status} metrics={metrics} websocketState={websocketState} />
-
-            <div className="grid gap-6 lg:grid-cols-3">
-              <div className="lg:col-span-2 space-y-6">
-                <ActiveCallsCard status={status} callHistory={callHistory} />
-                <CallHistoryTable history={callHistory} />
-                <ConfigEditor config={config} onSave={saveConfig} />
-              </div>
-              <div className="flex flex-col gap-6">
-                <LogsPanel logs={logs} />
-              </div>
-            </div>
-          </div>
+          <main className="grid gap-8 xl:grid-cols-[minmax(0,1fr)_340px]">
+            <section className="space-y-8">
+              <StatusOverview status={status} metrics={metrics} websocketState={websocketState} />
+              <ActiveCallsCard status={status} callHistory={callHistory} />
+              <CallHistoryTable history={callHistory} />
+              <ConfigEditor config={config} onSave={saveConfig} />
+            </section>
+            <aside className="space-y-8 xl:sticky xl:top-24">
+              <LogsPanel logs={logs} />
+            </aside>
+          </main>
         )}
       </div>
     </div>

--- a/web/src/components/ActiveCallsCard.tsx
+++ b/web/src/components/ActiveCallsCard.tsx
@@ -32,42 +32,50 @@ export const ActiveCallsCard = ({ status, callHistory }: ActiveCallsCardProps) =
 
   if (activeCallCount === 0) {
     return (
-      <div className="h-full rounded-2xl border border-dashed border-gray-300 bg-white/40 p-6 text-center text-sm text-gray-500 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-400">
-        <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800">
+      <div className="relative overflow-hidden rounded-3xl border border-dashed border-slate-300/80 bg-white/80 p-8 text-center shadow-sm backdrop-blur-sm dark:border-slate-700/70 dark:bg-white/5">
+        <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.12),_transparent_70%)] dark:bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.18),_transparent_80%)]" />
+        <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-500/10 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-200">
           <PhoneIcon className="h-6 w-6" />
         </div>
-        <p>No active calls right now.</p>
+        <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">No active calls right now.</h3>
+        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+          Call cards will appear here when the agent is managing live sessions.
+        </p>
       </div>
     )
   }
 
   return (
-    <div className="space-y-4 rounded-2xl border border-border-light bg-white/70 p-6 shadow-sm backdrop-blur dark:border-border-dark dark:bg-gray-900/70">
-      <div className="flex items-center justify-between">
+    <div className="relative overflow-hidden rounded-3xl border border-white/60 bg-white/80 p-6 shadow-sm backdrop-blur dark:border-white/10 dark:bg-white/5">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.12),_transparent_70%)] dark:bg-[radial-gradient(circle_at_top,_rgba(16,185,129,0.22),_transparent_85%)]" />
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
-          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-200">
+          <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-emerald-500/15 text-emerald-600 dark:bg-emerald-500/25 dark:text-emerald-200">
             <PhoneIcon className="h-6 w-6" />
           </div>
           <div>
-            <p className="text-lg font-semibold text-gray-900 dark:text-gray-100">Active calls</p>
-            <p className="text-sm text-gray-500 dark:text-gray-400">
+            <p className="text-lg font-semibold text-slate-900 dark:text-slate-100">Active calls</p>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
               Monitoring {activeCallCount} ongoing session{activeCallCount === 1 ? '' : 's'}
             </p>
           </div>
         </div>
+        <span className="inline-flex items-center justify-center rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-200">
+          Live
+        </span>
       </div>
 
-      <div className="space-y-3">
+      <div className="mt-6 grid gap-4 md:grid-cols-2">
         {activeHistory.map((item) => (
           <div
             key={item.call_id}
-            className="flex flex-col gap-1 rounded-xl border border-emerald-200/70 bg-emerald-50/80 p-4 text-sm text-emerald-800 shadow-sm transition hover:border-emerald-300 dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-200"
+            className="rounded-2xl border border-emerald-200/70 bg-gradient-to-br from-emerald-500/10 to-emerald-500/5 p-5 text-sm text-emerald-900 shadow-sm transition hover:border-emerald-300 dark:border-emerald-500/30 dark:from-emerald-500/20 dark:to-emerald-500/5 dark:text-emerald-100"
           >
-            <div className="flex items-center justify-between text-sm font-medium">
+            <div className="flex items-center justify-between text-sm font-semibold">
               <span>Call ID: {item.call_id}</span>
-              <span className="text-xs uppercase tracking-wide text-emerald-700/80 dark:text-emerald-300/80">Live</span>
+              <span className="text-xs uppercase tracking-wide text-emerald-600/90 dark:text-emerald-200/80">Streaming</span>
             </div>
-            <div className="flex flex-wrap items-center gap-x-6 gap-y-1 text-xs text-emerald-700/80 dark:text-emerald-300/80">
+            <div className="mt-3 flex flex-wrap gap-x-6 gap-y-1 text-xs text-emerald-700/90 dark:text-emerald-200/70">
               <span>Started {formatTimestamp(item.start)}</span>
               <span>Elapsed {formatDuration(item.start, null, now)}</span>
               {item.correlation_id ? <span>Correlation {item.correlation_id}</span> : null}

--- a/web/src/components/CallHistoryTable.tsx
+++ b/web/src/components/CallHistoryTable.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { ArrowDownTrayIcon, ClockIcon, DocumentTextIcon } from '@heroicons/react/24/outline'
 
 import type { CallHistoryItem } from '../types'
@@ -8,17 +9,45 @@ interface CallHistoryTableProps {
 }
 
 export const CallHistoryTable = ({ history }: CallHistoryTableProps) => {
+  const [isCompact, setIsCompact] = useState<boolean>(() => {
+    if (typeof window === 'undefined') {
+      return false
+    }
+    return window.innerWidth < 768
+  })
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return
+    }
+    const mediaQuery = window.matchMedia('(max-width: 767px)')
+    const handleChange = (event: MediaQueryListEvent | MediaQueryList) => {
+      setIsCompact(event.matches)
+    }
+
+    handleChange(mediaQuery)
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', handleChange)
+      return () => mediaQuery.removeEventListener('change', handleChange)
+    }
+
+    mediaQuery.addListener(handleChange)
+    return () => mediaQuery.removeListener(handleChange)
+  }, [])
+
   return (
-    <div className="overflow-hidden rounded-2xl border border-border-light bg-white/80 shadow-sm dark:border-border-dark dark:bg-gray-900/70">
-      <div className="flex flex-col gap-1 border-b border-gray-100 bg-gray-50/80 px-4 py-3 dark:border-gray-800 dark:bg-gray-800/60 sm:flex-row sm:items-center sm:justify-between">
+    <div className="overflow-hidden rounded-3xl border border-white/60 bg-white/80 shadow-sm backdrop-blur-sm dark:border-white/10 dark:bg-white/5">
+      <div className="flex flex-col gap-3 border-b border-slate-200/70 bg-gradient-to-r from-white/70 to-white/30 px-6 py-5 dark:border-white/10 dark:from-white/10 dark:to-white/5 md:flex-row md:items-center md:justify-between">
         <div>
-          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200">Call History</h2>
-          <p className="text-xs text-gray-500 dark:text-gray-400">Review completed calls or download a CSV export.</p>
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Call history</p>
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Completed and in-progress calls</h2>
+          <p className="text-xs text-slate-500 dark:text-slate-400">Review connection outcomes or export the latest records.</p>
         </div>
         <a
           href="/api/call_history.csv"
           download="call-history.csv"
-          className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-3 py-1.5 text-sm font-medium text-white shadow-sm transition hover:bg-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 dark:bg-blue-500 dark:hover:bg-blue-400 dark:focus:ring-offset-gray-900"
+          className="inline-flex items-center justify-center gap-2 self-start rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 dark:bg-blue-500 dark:hover:bg-blue-400 dark:focus:ring-offset-slate-900"
         >
           <ArrowDownTrayIcon className="h-4 w-4" />
           Download CSV
@@ -26,52 +55,90 @@ export const CallHistoryTable = ({ history }: CallHistoryTableProps) => {
       </div>
 
       {history.length === 0 ? (
-        <div className="flex h-48 flex-col items-center justify-center gap-3 px-4 text-center text-sm text-gray-500 dark:text-gray-400">
-          <DocumentTextIcon className="h-8 w-8" />
+        <div className="flex flex-col items-center justify-center gap-4 px-6 py-12 text-center text-sm text-slate-500 dark:text-slate-400">
+          <DocumentTextIcon className="h-10 w-10" />
           <p>Call history will appear once calls are completed.</p>
+        </div>
+      ) : isCompact ? (
+        <div className="divide-y divide-slate-200 text-sm text-slate-700 dark:divide-slate-800 dark:text-slate-200">
+          {history.map((item) => {
+            const isActive = item.end === null
+            return (
+              <div key={`${item.call_id}-${item.start}`} className="flex flex-col gap-3 px-5 py-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">Call {item.call_id}</p>
+                    <p className="text-xs text-slate-500 dark:text-slate-400">Correlation {item.correlation_id ?? '—'}</p>
+                  </div>
+                  <span
+                    className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium ${
+                      isActive
+                        ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-100'
+                        : 'bg-slate-100 text-slate-600 dark:bg-white/10 dark:text-slate-200'
+                    }`}
+                  >
+                    <ClockIcon className="h-4 w-4" />
+                    {isActive ? 'In progress' : 'Completed'}
+                  </span>
+                </div>
+                <div className="grid gap-2 text-xs text-slate-500 dark:text-slate-400">
+                  <div className="flex items-center justify-between">
+                    <span className="uppercase tracking-wide">Started</span>
+                    <span className="text-slate-700 dark:text-slate-200">{formatTimestamp(item.start)}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="uppercase tracking-wide">Ended</span>
+                    <span className="text-slate-700 dark:text-slate-200">{formatTimestamp(item.end ?? undefined)}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="uppercase tracking-wide">Duration</span>
+                    <span className="text-slate-700 dark:text-slate-200">{formatDuration(item.start, item.end)}</span>
+                  </div>
+                </div>
+              </div>
+            )
+          })}
         </div>
       ) : (
         <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
-            <thead className="bg-gray-50/80 text-left text-xs uppercase tracking-wide text-gray-500 dark:bg-gray-800/60 dark:text-gray-400">
+          <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
+            <thead className="bg-slate-50/70 text-left text-xs uppercase tracking-wide text-slate-500 dark:bg-white/5 dark:text-slate-400">
               <tr>
-                <th className="px-4 py-3">Call ID</th>
-                <th className="px-4 py-3">Correlation</th>
-                <th className="px-4 py-3">Started</th>
-                <th className="px-4 py-3">Ended</th>
-                <th className="px-4 py-3">Duration</th>
-                <th className="px-4 py-3 text-right">Status</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100 text-sm text-gray-700 dark:divide-gray-800 dark:text-gray-200">
-              {history.map((item) => {
-                const isActive = item.end === null
-                return (
-                  <tr key={`${item.call_id}-${item.start}`} className="hover:bg-gray-50/60 dark:hover:bg-gray-800/40">
-                    <td className="whitespace-nowrap px-4 py-3 font-medium">{item.call_id}</td>
-                    <td className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400">
-                      {item.correlation_id ?? '—'}
-                    </td>
-                    <td className="px-4 py-3">{formatTimestamp(item.start)}</td>
-                    <td className="px-4 py-3">{formatTimestamp(item.end ?? undefined)}</td>
-                    <td className="px-4 py-3 text-sm">{formatDuration(item.start, item.end)}</td>
-                    <td className="px-4 py-3 text-right">
-                      <span
-                        className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium ${
-                          isActive
-                            ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-200'
-                            : 'bg-gray-100 text-gray-600 dark:bg-gray-800/60 dark:text-gray-300'
-                        }`}
-                      >
-                        <ClockIcon className="h-4 w-4" />
-                        {isActive ? 'In progress' : 'Completed'}
-                      </span>
-                    </td>
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
+                  <th className="px-6 py-3">Call ID</th>
+                  <th className="px-6 py-3">Correlation</th>
+                  <th className="px-6 py-3">Started</th>
+                  <th className="px-6 py-3">Ended</th>
+                  <th className="px-6 py-3">Duration</th>
+                  <th className="px-6 py-3 text-right">Status</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 text-sm text-slate-700 dark:divide-slate-800 dark:text-slate-200">
+                {history.map((item) => {
+                  const isActive = item.end === null
+                  return (
+                    <tr key={`${item.call_id}-${item.start}`} className="hover:bg-slate-50/60 dark:hover:bg-white/5">
+                      <td className="whitespace-nowrap px-6 py-4 font-semibold">{item.call_id}</td>
+                      <td className="px-6 py-4 text-xs text-slate-500 dark:text-slate-400">{item.correlation_id ?? '—'}</td>
+                      <td className="px-6 py-4">{formatTimestamp(item.start)}</td>
+                      <td className="px-6 py-4">{formatTimestamp(item.end ?? undefined)}</td>
+                      <td className="px-6 py-4 text-sm">{formatDuration(item.start, item.end)}</td>
+                      <td className="px-6 py-4 text-right">
+                        <span
+                          className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium ${
+                            isActive
+                              ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-100'
+                              : 'bg-slate-100 text-slate-600 dark:bg-white/10 dark:text-slate-200'
+                          }`}
+                        >
+                          <ClockIcon className="h-4 w-4" />
+                          {isActive ? 'In progress' : 'Completed'}
+                        </span>
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
         </div>
       )}
     </div>

--- a/web/src/components/ConfigEditor.tsx
+++ b/web/src/components/ConfigEditor.tsx
@@ -94,28 +94,29 @@ export const ConfigEditor = ({ config, onSave }: ConfigEditorProps) => {
   }
 
   return (
-    <div className="rounded-2xl border border-border-light bg-white/80 p-6 shadow-sm backdrop-blur dark:border-border-dark dark:bg-gray-900/70">
+    <div className="relative overflow-hidden rounded-3xl border border-white/60 bg-white/80 p-6 shadow-sm backdrop-blur-sm dark:border-white/10 dark:bg-white/5 sm:p-8">
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.12),_transparent_75%)] dark:bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.18),_transparent_80%)]" />
       <form className="space-y-6" onSubmit={handleSubmit}>
-        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex items-center gap-3">
-            <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-blue-100 text-blue-600 dark:bg-blue-900/40 dark:text-blue-300">
+            <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-blue-500/10 text-blue-600 dark:bg-blue-500/20 dark:text-blue-200">
               <AdjustmentsHorizontalIcon className="h-6 w-6" />
             </div>
-            <div>
-              <p className="text-lg font-semibold text-gray-900 dark:text-gray-100">Configuration</p>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                Update SIP and agent parameters. Restart required after saving.
+            <div className="space-y-1">
+              <p className="text-lg font-semibold text-slate-900 dark:text-slate-100">Configuration</p>
+              <p className="text-sm text-slate-500 dark:text-slate-400">
+                Update SIP and agent parameters with instant environment persistence.
               </p>
             </div>
           </div>
-          <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
-            <CheckCircleIcon className="h-5 w-5" />
+          <div className="flex items-center gap-2 rounded-full bg-slate-900/5 px-3 py-1 text-xs text-slate-500 dark:bg-white/5 dark:text-slate-300">
+            <CheckCircleIcon className="h-4 w-4" />
             <span>Changes persist to the .env file</span>
           </div>
         </div>
 
         {successMessage ? (
-          <div className="flex items-start gap-3 rounded-xl border border-emerald-200 bg-emerald-50/70 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-950/40 dark:text-emerald-200">
+          <div className="flex items-start gap-3 rounded-2xl border border-emerald-200 bg-emerald-50/80 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-500/40 dark:bg-emerald-500/10 dark:text-emerald-100">
             {reloadStatus?.status === 'restarting' ? (
               <ArrowPathIcon className="mt-0.5 h-5 w-5 animate-spin" />
             ) : (
@@ -123,38 +124,36 @@ export const ConfigEditor = ({ config, onSave }: ConfigEditorProps) => {
             )}
             <div className="space-y-1">
               <p>{successMessage}</p>
-              {reloadDetail ? (
-                <p className="text-xs text-emerald-700/80 dark:text-emerald-200/80">{reloadDetail}</p>
-              ) : null}
+              {reloadDetail ? <p className="text-xs text-emerald-600 dark:text-emerald-200/80">{reloadDetail}</p> : null}
             </div>
           </div>
         ) : null}
         {errorMessage ? (
-          <div className="rounded-xl border border-rose-200 bg-rose-50/70 px-4 py-3 text-sm text-rose-700 dark:border-rose-900/60 dark:bg-rose-950/40 dark:text-rose-200">
+          <div className="rounded-2xl border border-rose-200 bg-rose-50/80 px-4 py-3 text-sm text-rose-700 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-100">
             {errorMessage}
           </div>
         ) : null}
 
-        <div className="grid gap-4 md:grid-cols-2">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {CONFIG_KEYS.map((key) => {
             const value = formValues[key] ?? ''
             const isTextarea = textareaKeys.includes(key)
             return (
-              <label key={key} className="flex flex-col gap-2 text-sm font-medium text-gray-700 dark:text-gray-200">
-                <span className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">{key}</span>
+              <label key={key} className="flex flex-col gap-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+                <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">{key}</span>
                 {isTextarea ? (
                   <textarea
                     value={value}
                     onChange={(event) => handleChange(key, event.target.value)}
-                    rows={5}
-                    className="rounded-xl border border-gray-300 bg-white/80 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-gray-700 dark:bg-gray-900/70 dark:text-gray-100 dark:focus:border-blue-400 dark:focus:ring-blue-900/60"
+                    rows={6}
+                    className="min-h-[160px] rounded-2xl border border-slate-200/80 bg-white/90 px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-white/10 dark:bg-white/5 dark:text-slate-100 dark:focus:border-blue-400 dark:focus:ring-blue-900/60"
                   />
                 ) : (
                   <input
                     type="text"
                     value={value}
                     onChange={(event) => handleChange(key, event.target.value)}
-                    className="rounded-xl border border-gray-300 bg-white/80 px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-gray-700 dark:bg-gray-900/70 dark:text-gray-100 dark:focus:border-blue-400 dark:focus:ring-blue-900/60"
+                    className="rounded-2xl border border-slate-200/80 bg-white/90 px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 dark:border-white/10 dark:bg-white/5 dark:text-slate-100 dark:focus:border-blue-400 dark:focus:ring-blue-900/60"
                   />
                 )}
               </label>
@@ -162,15 +161,15 @@ export const ConfigEditor = ({ config, onSave }: ConfigEditorProps) => {
           })}
         </div>
 
-        <div className="flex flex-col gap-3 border-t border-gray-100 pt-4 text-sm dark:border-gray-800 md:flex-row md:items-center md:justify-between">
-          <div className="text-xs text-gray-500 dark:text-gray-400">
+        <div className="flex flex-col gap-4 border-t border-slate-200/70 pt-4 text-sm dark:border-white/10 lg:flex-row lg:items-center lg:justify-between">
+          <div className="text-xs text-slate-500 dark:text-slate-400">
             Saving applies immediately to the environment file. Restart containers to propagate changes.
           </div>
-          <div className="flex gap-3">
+          <div className="flex flex-col gap-3 sm:flex-row">
             <button
               type="button"
               onClick={handleReset}
-              className="inline-flex items-center gap-2 rounded-full border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 transition hover:border-gray-400 hover:text-gray-800 dark:border-gray-700 dark:text-gray-300 dark:hover:border-gray-600 dark:hover:text-gray-100"
+              className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-800 dark:border-white/20 dark:text-slate-200 dark:hover:border-white/40 dark:hover:text-white"
             >
               <ArrowPathIcon className={`h-4 w-4 ${saving ? 'animate-spin' : ''}`} />
               Reset
@@ -178,7 +177,7 @@ export const ConfigEditor = ({ config, onSave }: ConfigEditorProps) => {
             <button
               type="submit"
               disabled={!hasChanges || saving}
-              className="inline-flex items-center gap-2 rounded-full bg-blue-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+              className="inline-flex items-center justify-center gap-2 rounded-full bg-blue-600 px-6 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
             >
               {saving ? 'Saving…' : 'Save changes'}
             </button>

--- a/web/src/components/ErrorBanner.tsx
+++ b/web/src/components/ErrorBanner.tsx
@@ -7,16 +7,18 @@ interface ErrorBannerProps {
 
 export const ErrorBanner = ({ message, onRetry }: ErrorBannerProps) => {
   return (
-    <div className="flex items-center justify-between gap-4 rounded-2xl border border-rose-200 bg-rose-50/80 px-4 py-3 text-sm text-rose-700 dark:border-rose-900/60 dark:bg-rose-950/40 dark:text-rose-200">
-      <div className="flex items-center gap-2">
-        <ExclamationTriangleIcon className="h-5 w-5" />
-        <span>{message}</span>
+    <div className="flex flex-col gap-3 rounded-2xl border border-rose-200/80 bg-rose-50/90 px-4 py-3 text-sm text-rose-700 shadow-sm dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-100 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex items-start gap-3">
+        <span className="flex h-9 w-9 items-center justify-center rounded-2xl bg-rose-500/20 text-rose-600 dark:bg-rose-500/30 dark:text-rose-100">
+          <ExclamationTriangleIcon className="h-5 w-5" />
+        </span>
+        <span className="leading-snug">{message}</span>
       </div>
       {onRetry ? (
         <button
           type="button"
           onClick={onRetry}
-          className="rounded-full border border-rose-300 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-700 transition hover:bg-rose-100 dark:border-rose-700 dark:text-rose-200 dark:hover:bg-rose-900/40"
+          className="inline-flex items-center justify-center rounded-full border border-rose-300 px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-rose-700 transition hover:bg-rose-100 dark:border-rose-400/60 dark:text-rose-100 dark:hover:bg-rose-500/20"
         >
           Retry
         </button>

--- a/web/src/components/LogsPanel.tsx
+++ b/web/src/components/LogsPanel.tsx
@@ -15,20 +15,23 @@ export const LogsPanel = ({ logs }: LogsPanelProps) => {
   }, [logs])
 
   return (
-    <div className="flex h-full flex-col rounded-2xl border border-border-light bg-gray-950 text-gray-100 shadow-sm dark:border-gray-800">
-      <div className="flex items-center justify-between border-b border-border-light/40 px-4 py-3 dark:border-gray-800">
-        <div className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-gray-400">
-          <ListBulletIcon className="h-5 w-5" />
+    <div className="relative flex h-full flex-col overflow-hidden rounded-3xl border border-slate-900/30 bg-slate-950/90 text-slate-100 shadow-xl ring-1 ring-white/10 backdrop-blur-sm dark:border-white/10">
+      <div className="absolute inset-x-0 top-0 h-24 bg-gradient-to-b from-blue-500/10 to-transparent" aria-hidden />
+      <div className="relative flex items-center justify-between border-b border-white/10 px-6 py-4">
+        <div className="flex items-center gap-3 text-sm font-semibold uppercase tracking-wide text-slate-300">
+          <span className="flex h-9 w-9 items-center justify-center rounded-2xl bg-blue-500/20 text-blue-200">
+            <ListBulletIcon className="h-5 w-5" />
+          </span>
           Live logs
         </div>
-        <span className="text-xs text-gray-500">{logs.length} entries</span>
+        <span className="text-xs text-slate-500">{logs.length} entries</span>
       </div>
-      <div ref={containerRef} className="flex-1 space-y-1 overflow-y-auto bg-black/20 p-4 text-xs font-mono leading-relaxed">
+      <div ref={containerRef} className="relative flex-1 space-y-1 overflow-y-auto px-6 py-5 text-xs font-mono leading-relaxed">
         {logs.length === 0 ? (
-          <p className="text-gray-500">No log entries yet. System output will appear here.</p>
+          <p className="text-slate-500">No log entries yet. System output will appear here.</p>
         ) : (
           logs.map((line, index) => (
-            <div key={`${index}-${line}`} className="whitespace-pre-wrap break-words text-gray-200">
+            <div key={`${index}-${line}`} className="whitespace-pre-wrap break-words text-slate-200/90">
               {line}
             </div>
           ))

--- a/web/src/components/StatusOverview.tsx
+++ b/web/src/components/StatusOverview.tsx
@@ -16,6 +16,45 @@ interface StatusOverviewProps {
 
 type Tone = 'default' | 'success' | 'danger' | 'warning'
 
+const toneStyles: Record<
+  Tone,
+  {
+    container: string
+    icon: string
+    value: string
+    description: string
+  }
+> = {
+  default: {
+    container:
+      'border-slate-200/80 bg-white/80 text-slate-900 dark:border-white/10 dark:bg-white/5 dark:text-slate-100',
+    icon: 'bg-slate-900/5 text-slate-700 dark:bg-white/10 dark:text-slate-200',
+    value: 'text-slate-900 dark:text-slate-100',
+    description: 'text-slate-500 dark:text-slate-400',
+  },
+  success: {
+    container:
+      'border-emerald-200/80 bg-emerald-50/80 text-emerald-800 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-100',
+    icon: 'bg-emerald-500/15 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-100',
+    value: 'text-emerald-700 dark:text-emerald-100',
+    description: 'text-emerald-600 dark:text-emerald-200/80',
+  },
+  danger: {
+    container:
+      'border-rose-200/80 bg-rose-50/80 text-rose-800 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-100',
+    icon: 'bg-rose-500/15 text-rose-600 dark:bg-rose-500/20 dark:text-rose-100',
+    value: 'text-rose-700 dark:text-rose-100',
+    description: 'text-rose-600 dark:text-rose-200/80',
+  },
+  warning: {
+    container:
+      'border-amber-200/80 bg-amber-50/80 text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100',
+    icon: 'bg-amber-500/15 text-amber-600 dark:bg-amber-500/20 dark:text-amber-100',
+    value: 'text-amber-700 dark:text-amber-100',
+    description: 'text-amber-600 dark:text-amber-200/80',
+  },
+}
+
 const StatCard = ({
   icon: Icon,
   title,
@@ -29,27 +68,20 @@ const StatCard = ({
   description?: string
   tone?: Tone
 }) => {
-  const base =
-    'flex items-center gap-4 rounded-2xl border border-border-light bg-white/70 p-4 shadow-sm backdrop-blur dark:border-border-dark dark:bg-gray-900/70'
-  const toneClasses: Record<Tone, string> = {
-    default: '',
-    success: 'border-emerald-200 bg-emerald-50/80 text-emerald-700 dark:border-emerald-900/70 dark:bg-emerald-950/50 dark:text-emerald-300',
-    danger: 'border-rose-200 bg-rose-50/80 text-rose-700 dark:border-rose-900/70 dark:bg-rose-950/50 dark:text-rose-300',
-    warning:
-      'border-amber-200 bg-amber-50/80 text-amber-700 dark:border-amber-900/70 dark:bg-amber-950/50 dark:text-amber-200',
-  }
+  const styles = toneStyles[tone]
 
   return (
-    <div className={`${base} ${toneClasses[tone]}`}>
-      <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-white/60 shadow-inner dark:bg-gray-800/60">
+    <div
+      className={`group relative overflow-hidden rounded-2xl border p-5 shadow-sm backdrop-blur-sm transition duration-200 hover:-translate-y-0.5 hover:shadow-md ${styles.container}`}
+    >
+      <div className="absolute -right-6 top-6 h-24 w-24 rounded-full bg-white/10 opacity-0 transition-opacity duration-200 group-hover:opacity-100 dark:bg-white/10" />
+      <div className={`inline-flex h-12 w-12 items-center justify-center rounded-xl ${styles.icon}`}>
         <Icon className="h-6 w-6" />
       </div>
-      <div className="flex-1">
-        <p className="text-sm font-medium text-gray-500 dark:text-gray-400">{title}</p>
-        <p className="text-xl font-semibold text-gray-900 dark:text-gray-100">{value}</p>
-        {description ? (
-          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{description}</p>
-        ) : null}
+      <div className="mt-4 space-y-1">
+        <p className="text-xs font-medium uppercase tracking-wide text-slate-500/80 dark:text-slate-400/80">{title}</p>
+        <p className={`text-2xl font-semibold leading-tight ${styles.value}`}>{value}</p>
+        {description ? <p className={`text-xs ${styles.description}`}>{description}</p> : null}
       </div>
     </div>
   )
@@ -71,7 +103,7 @@ export const StatusOverview = ({ status, metrics, websocketState }: StatusOvervi
     closed: 'Offline',
   }
 
-  const realtimeTone: 'success' | 'danger' | 'warning' | 'default' = sipRegistered
+  const realtimeTone: Tone = sipRegistered
     ? realtimeState === 'healthy'
       ? 'success'
       : realtimeState === 'unhealthy'
@@ -80,7 +112,7 @@ export const StatusOverview = ({ status, metrics, websocketState }: StatusOvervi
     : 'warning'
 
   return (
-    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
       <StatCard
         icon={sipRegistered ? CheckCircleIcon : ExclamationTriangleIcon}
         title="SIP registration"
@@ -97,7 +129,13 @@ export const StatusOverview = ({ status, metrics, websocketState }: StatusOvervi
       <StatCard
         icon={SignalIcon}
         title="Realtime channel"
-        value={realtimeState === 'healthy' ? 'Healthy' : realtimeState === 'unhealthy' ? 'Unhealthy' : realtimeState}
+        value={
+          realtimeState === 'healthy'
+            ? 'Healthy'
+            : realtimeState === 'unhealthy'
+              ? 'Unhealthy'
+              : realtimeState
+        }
         description={realtimeDescription}
         tone={realtimeTone}
       />

--- a/web/src/components/ThemeToggle.tsx
+++ b/web/src/components/ThemeToggle.tsx
@@ -11,9 +11,11 @@ export const ThemeToggle = () => {
     <button
       type="button"
       onClick={toggleTheme}
-      className="inline-flex items-center gap-2 rounded-full border border-border-light bg-white/80 px-4 py-2 text-sm font-medium text-gray-700 shadow-sm backdrop-blur transition hover:bg-white dark:border-border-dark dark:bg-gray-800/80 dark:text-gray-200 dark:hover:bg-gray-700"
+      className="inline-flex items-center gap-2 rounded-full border border-slate-200/70 bg-white/80 px-4 py-2 text-sm font-medium text-slate-700 shadow-sm backdrop-blur-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-white/10 dark:bg-white/10 dark:text-slate-200"
     >
-      {isDark ? <MoonIcon className={iconClasses} /> : <SunIcon className={iconClasses} />}
+      <span className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-900/5 text-slate-700 dark:bg-white/10 dark:text-slate-100">
+        {isDark ? <MoonIcon className={iconClasses} /> : <SunIcon className={iconClasses} />}
+      </span>
       <span>{isDark ? 'Dark mode' : 'Light mode'}</span>
     </button>
   )

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -7,7 +7,7 @@
 }
 
 body {
-  @apply bg-gray-50 text-gray-900 dark:bg-surface-dark dark:text-gray-100;
+  @apply bg-slate-100 text-slate-900 dark:bg-slate-950 dark:text-slate-100;
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
@@ -20,5 +20,5 @@ a {
 }
 
 ::-webkit-scrollbar-thumb {
-  @apply bg-gray-400/60 rounded-full;
+  @apply rounded-full bg-slate-400/60;
 }


### PR DESCRIPTION
## Summary
- refresh the dashboard hero with a gradient backdrop, refreshed header content, and a responsive two-column layout with a sticky logs column
- restyle the status, active calls, call history, and configuration cards to introduce glassmorphism details and clearer empty states
- add a compact call history layout for small screens and refine supporting components like the logs panel, theme toggle, and error banner

## Testing
- npm run lint
- npm run test


------
https://chatgpt.com/codex/tasks/task_b_68cd8bbc290c832da36240eb439e3167