### PR TITLE
Fix missing importlib dependency in tests

### DIFF
--- a/tests/test_endpoint_timer.py
+++ b/tests/test_endpoint_timer.py
@@ -1,3 +1,4 @@
+import importlib
 import sys
 import types
 


### PR DESCRIPTION
## Summary
- add the missing importlib import to tests/test_endpoint_timer.py to satisfy lint checks

## Testing
- make lint

------
https://chatgpt.com/codex/tasks/task_b_68cd8fb2f2e8832dbf02682990bb8a29