### PR TITLE
Handle missing settings cache when updating config

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -290,6 +290,14 @@ def get_settings() -> Settings:
         raise ConfigurationError(message, details=details) from exc
 
 
+def reset_settings_cache() -> None:
+    """Clear the cached :func:`get_settings` result when available."""
+
+    cache_clear = getattr(get_settings, "cache_clear", None)
+    if callable(cache_clear):
+        cache_clear()
+
+
 def env_file_path() -> Path:
     """Return the path to the runtime ``.env`` file."""
 

--- a/app/monitor.py
+++ b/app/monitor.py
@@ -41,6 +41,7 @@ try:
         get_settings,
         merge_env,
         read_env_file,
+        reset_settings_cache,
         validate_env_map,
         write_env_file,
     )
@@ -54,6 +55,7 @@ except ImportError as exc:  # pragma: no cover - script execution fallback
             get_settings,
             merge_env,
             read_env_file,
+            reset_settings_cache,
             validate_env_map,
             write_env_file,
         )
@@ -92,7 +94,7 @@ def save_config(new_config: dict) -> None:
     merged = merge_env(existing, new_config)
     validate_env_map(merged, include_os_environ=False)
     write_env_file(merged)
-    get_settings.cache_clear()
+    reset_settings_cache()
 
 
 class Monitor:


### PR DESCRIPTION
## Summary
- add a helper in `app.config` to reset the cached settings safely
- use the helper in the monitor configuration save path to avoid AttributeError when `get_settings` is patched

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cd90abfb9c832da8a6b4fff1966f78