### PR TITLE
Fix mypy error in session expiry handling

### DIFF
--- a/app/monitor.py
+++ b/app/monitor.py
@@ -208,11 +208,13 @@ class Monitor:
         if payload:
             session_id = str(payload.get("session_id", "")) or None
             username = str(payload.get("username", ""))
-            expires_at = payload.get("expires_at")
             if not session_id or not username:
                 return None
+            expires_at_raw = cast(Optional[float | int | str], payload.get("expires_at"))
+            if expires_at_raw is None:
+                return None
             try:
-                expires_value = float(expires_at)
+                expires_value = float(expires_at_raw)
             except (TypeError, ValueError):
                 return None
             if expires_value < now:


### PR DESCRIPTION
## Summary
- guard decoded session payload fields against missing values before parsing expiry timestamps
- cast the stored expiry payload to supported float inputs so mypy accepts the conversion

## Testing
- make type

------
https://chatgpt.com/codex/tasks/task_b_68ce43b108d4832d90b280f5eed38824