### PR TITLE
Handle HTML error responses in dashboard fetch

### DIFF
--- a/web/src/hooks/useDashboardData.ts
+++ b/web/src/hooks/useDashboardData.ts
@@ -1,33 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import type { CallHistoryItem, DashboardEvent, MetricsSnapshot, StatusPayload } from '../types'
-
-class UnauthorizedError extends Error {
-  constructor(message = 'Authentication required') {
-    super(message)
-    this.name = 'UnauthorizedError'
-  }
-}
-
-const fetchJson = async <T>(url: string): Promise<T> => {
-  const response = await fetch(url, {
-    credentials: 'include',
-    headers: {
-      Accept: 'application/json',
-    },
-  })
-
-  if (response.status === 401) {
-    throw new UnauthorizedError()
-  }
-
-  if (!response.ok) {
-    const text = await response.text()
-    throw new Error(text || response.statusText)
-  }
-
-  return response.json() as Promise<T>
-}
+import { UnauthorizedError, fetchJson } from '../utils/http'
 
 export interface DashboardData {
   status: StatusPayload | null

--- a/web/src/utils/__tests__/http.test.ts
+++ b/web/src/utils/__tests__/http.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchJson, sanitizeErrorMessage, UnauthorizedError } from '../http'
+
+const htmlError = `<!DOCTYPE html>
+<html>
+<head><title>502 Bad Gateway</title></head>
+<body><center><h1>502 Bad Gateway</h1></center></body>
+</html>`
+
+describe('sanitizeErrorMessage', () => {
+  it('returns plain text when html is provided', () => {
+    expect(sanitizeErrorMessage(htmlError, 'text/html')).toBe('502 Bad Gateway')
+  })
+
+  it('returns the trimmed original message for non-html content', () => {
+    expect(sanitizeErrorMessage('   Something went wrong  ')).toBe('Something went wrong')
+  })
+})
+
+describe('fetchJson', () => {
+  const originalFetch = globalThis.fetch
+
+  beforeEach(() => {
+    if (!globalThis.fetch) {
+      globalThis.fetch = vi.fn() as unknown as typeof fetch
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    if (originalFetch) {
+      globalThis.fetch = originalFetch
+    } else {
+      delete (globalThis as { fetch?: typeof fetch }).fetch
+    }
+  })
+
+  it('parses successful JSON responses', async () => {
+    const payload = { ok: true }
+    const textSpy = vi.fn().mockResolvedValue(JSON.stringify(payload))
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      ok: true,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      text: textSpy,
+    } as unknown as Response)
+
+    await expect(fetchJson<typeof payload>('/api/status')).resolves.toEqual(payload)
+    expect(fetchSpy).toHaveBeenCalledWith('/api/status', expect.objectContaining({
+      credentials: 'include',
+    }))
+    expect(textSpy).toHaveBeenCalled()
+  })
+
+  it('throws UnauthorizedError for 401 responses', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      status: 401,
+      statusText: 'Unauthorized',
+      ok: false,
+      headers: new Headers(),
+      text: vi.fn(),
+    } as unknown as Response)
+
+    await expect(fetchJson('/api/status')).rejects.toBeInstanceOf(UnauthorizedError)
+  })
+
+  it('uses sanitized html error messages', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      status: 502,
+      statusText: 'Bad Gateway',
+      ok: false,
+      headers: new Headers({ 'content-type': 'text/html' }),
+      text: vi.fn().mockResolvedValue(htmlError),
+    } as unknown as Response)
+
+    await expect(fetchJson('/api/status')).rejects.toThrow('502 Bad Gateway')
+  })
+})

--- a/web/src/utils/http.ts
+++ b/web/src/utils/http.ts
@@ -1,0 +1,110 @@
+export class UnauthorizedError extends Error {
+  constructor(message = 'Authentication required') {
+    super(message)
+    this.name = 'UnauthorizedError'
+  }
+}
+
+const isLikelyHtml = (text: string, contentType: string): boolean => {
+  if (!text.trim()) {
+    return false
+  }
+
+  const lowerType = contentType.toLowerCase()
+  if (lowerType.includes('text/html') || lowerType.includes('application/xhtml+xml')) {
+    return true
+  }
+
+  return /<[a-z!][\s\S]*>/i.test(text)
+}
+
+export const sanitizeErrorMessage = (raw: string, contentType = ''): string => {
+  const text = raw.trim()
+  if (!text) {
+    return ''
+  }
+
+  if (!isLikelyHtml(text, contentType)) {
+    return text
+  }
+
+  const titleMatch = text.match(/<title[^>]*>([^<]*)<\/title>/i)
+  if (titleMatch?.[1]?.trim()) {
+    return titleMatch[1].trim()
+  }
+
+  const headingMatch = text.match(/<h1[^>]*>([^<]*)<\/h1>/i)
+  if (headingMatch?.[1]?.trim()) {
+    return headingMatch[1].trim()
+  }
+
+  return text.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()
+}
+
+const parseJson = <T>(payload: string): T => {
+  const trimmed = payload.trim()
+  if (!trimmed) {
+    throw new Error('Empty response body')
+  }
+  return JSON.parse(trimmed) as T
+}
+
+export const fetchJson = async <T>(url: string, init?: RequestInit): Promise<T> => {
+  const headers = new Headers(init?.headers ?? {})
+  if (!headers.has('Accept')) {
+    headers.set('Accept', 'application/json')
+  }
+
+  const response = await fetch(url, {
+    ...init,
+    headers,
+    credentials: init?.credentials ?? 'include',
+  })
+
+  if (response.status === 401) {
+    throw new UnauthorizedError()
+  }
+
+  const contentType = response.headers.get('content-type') ?? ''
+  const bodyText = await response.text()
+
+  if (response.ok) {
+    try {
+      return parseJson<T>(bodyText)
+    } catch {
+      throw new Error('Unexpected response format')
+    }
+  }
+
+  let message: string | null = null
+
+  if (contentType.toLowerCase().includes('application/json')) {
+    try {
+      const payload = parseJson<Record<string, unknown>>(bodyText)
+      if (payload && typeof payload === 'object') {
+        const detail = payload.detail
+        const error = payload.error
+        if (typeof detail === 'string' && detail.trim()) {
+          message = detail.trim()
+        } else if (typeof error === 'string' && error.trim()) {
+          message = error.trim()
+        }
+      }
+    } catch {
+      // ignore parse errors and fall back to sanitised text below
+    }
+  }
+
+  if (!message) {
+    const sanitized = sanitizeErrorMessage(bodyText, contentType)
+    if (sanitized) {
+      message = sanitized
+    }
+  }
+
+  if (!message) {
+    message = response.statusText || `Request failed with status ${response.status}`
+  }
+
+  throw new Error(message)
+}


### PR DESCRIPTION
## Summary
- centralize JSON fetching in a shared helper that strips HTML error payloads down to readable text
- update the dashboard data hook to use the new helper so 502 Bad Gateway pages no longer render inside the UI
- add unit tests covering the sanitisation logic and fetch behaviour

## Testing
- pytest -q
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68ce4dc2fe84832da4dbfdf6063e6c95