### PR TITLE
Normalize SIP codec preferences for PJSIP enumerations

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Defaults originate from `env.example` and are enforced via the `Settings` datacl
 | Key | Default | Description |
 | --- | --- | --- |
 | `SIP_TRANSPORT_PORT` | `5060` | Local UDP port for SIP signalling. |
-| `SIP_PREFERRED_CODECS` | `PCMU,PCMA,opus` | Priority-ordered codec list; unavailable codecs are ignored. |
+| `SIP_PREFERRED_CODECS` | `PCMU,PCMA,opus` | Priority-ordered codec list; friendly names (e.g. `PCMU`, `opus`) are normalised to the codec IDs reported by PJSIP and unavailable codecs are ignored. |
 | `SIP_JB_MIN` / `SIP_JB_MAX` / `SIP_JB_MAX_PRE` | `0` | Jitter buffer bounds to trade latency for resilience. |
 
 These values adjust PJSIP media configuration before registration.

--- a/env.example
+++ b/env.example
@@ -18,6 +18,8 @@ SYSTEM_PROMPT=You are a helpful voice assistant.
 
 # Audio pipeline
 SIP_TRANSPORT_PORT=5060
+# Codec names can be specified as friendly aliases like PCMU or opus; the agent
+# normalises them to the codec identifiers reported by PJSIP at runtime.
 SIP_PREFERRED_CODECS=PCMU,PCMA,opus
 SIP_JB_MIN=0
 SIP_JB_MAX=0

--- a/tests/test_agent_startup.py
+++ b/tests/test_agent_startup.py
@@ -49,3 +49,36 @@ def test_main_with_configuration_error_keeps_monitor_running(monkeypatch: pytest
     assert any("Configuration validation failed" in message for message in log_messages)
     assert any("SIP_DOMAIN missing" in message for message in log_messages)
     assert any("configuration fixes" in message for message in log_messages)
+
+
+def test_apply_codec_preferences_matches_aliases(monkeypatch: pytest.MonkeyPatch) -> None:
+    monitor = DummyMonitor()
+    monkeypatch.setattr(agent, "monitor", monitor)
+
+    class FakeInfo:
+        def __init__(self, codec_id: str) -> None:
+            self.codecId = codec_id
+
+    class FakeEndpoint:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, int]] = []
+
+        def codecEnum2(self):  # pragma: no cover - exercised in test
+            return [FakeInfo("pcmu/8000/1"), FakeInfo("opus/48000/2")]
+
+        def codecSetPriority(self, codec: str, priority: int) -> None:  # pragma: no cover - stub
+            self.calls.append((codec, priority))
+
+    endpoint = FakeEndpoint()
+
+    agent._apply_codec_preferences(endpoint, ("PCMU", "OpUs", "g722"))
+
+    assert endpoint.calls == [("pcmu/8000/1", 240), ("opus/48000/2", 230)]
+
+    applied_logs = [fields for message, fields in monitor.logs if fields.get("event") == "codec_preference_applied"]
+    assert applied_logs, "Expected applied codec log entry"
+    assert applied_logs[0]["applied_codecs"][0]["codec_id"] == "pcmu/8000/1"
+
+    missing_logs = [fields for message, fields in monitor.logs if fields.get("event") == "codec_preference_missing"]
+    assert missing_logs, "Expected warning for unavailable codecs"
+    assert missing_logs[0]["requested_codecs"] == ["g722"]


### PR DESCRIPTION
## Summary
- normalise SIP codec preference handling so friendly aliases map onto the codec identifiers returned by pjsua and record applied or missing codecs in the monitor log
- document the codec alias behaviour in the README and sample environment file
- cover the codec preference helper with a unit test

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_b_68ce5780d484832daf06ab4ad9f270cc